### PR TITLE
Improve development setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Device Control Application
 
 Cross-platform desktop application written in **C++20** using **Qt**.
+
 Target platforms:
 - Linux
 - Windows
@@ -12,14 +13,19 @@ Target platforms:
 - Qt 6.x (or Qt 5.15.x)
 - Ninja (recommended)
 
+## Development setup
+See [docs/dev-setup.md](docs/dev-setup.md).
+
 ## Build (Linux / macOS)
 ```bash
 cmake --preset release
 cmake --build --preset release
 ctest --preset release
-# Microfludics-Workstation-Automation
+```
 
-##Windows
+## Build (Windows)
+```bash
 cmake --preset windows-release
 cmake --build --preset windows-release
 ctest --preset windows-release
+```

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,14 +1,52 @@
-sudo apt install build-essential cmake ninja-build
+# Development setup
 
-Install Qt via official installer or distribution packages.
+## Linux (Ubuntu/Debian)
+```bash
+sudo apt update
+sudo apt install -y build-essential cmake ninja-build
+```
+
+Install Qt via the official installer or distribution packages (Qt 6.x preferred).
+If Qt is not on your `PATH`, set `CMAKE_PREFIX_PATH` to the Qt install prefix.
+
+Example (Qt installer default):
+```bash
+export CMAKE_PREFIX_PATH="$HOME/Qt/6.6.0/gcc_64"
+```
+
+## macOS
+```bash
 brew install cmake ninja
+```
 
-Install Qt via official installer.
+Install Qt via the official installer (Qt 6.x preferred). If Qt is not on your
+`PATH`, set `CMAKE_PREFIX_PATH` to the Qt install prefix.
 
-Windows
+Example:
+```bash
+export CMAKE_PREFIX_PATH="$HOME/Qt/6.6.0/macos"
+```
 
-Install Visual Studio 2022 (Desktop C++)
+## Windows
+- Install Visual Studio 2022 with the "Desktop development with C++" workload.
+- Install Qt (MSVC build) via the official installer.
+- Ensure Qt is discoverable via `PATH` or set `CMAKE_PREFIX_PATH`.
 
-Install Qt (MSVC build)
+Example (PowerShell):
+```powershell
+$env:CMAKE_PREFIX_PATH = "C:\Qt\6.6.0\msvc2019_64"
+```
 
-Ensure Qt is discoverable via PATH or CMAKE_PREFIX_PATH
+## Build & test
+```bash
+cmake --preset release
+cmake --build --preset release
+ctest --preset release
+```
+
+If you need a debug build, use the `debug` preset:
+```bash
+cmake --preset debug
+cmake --build --preset debug
+ctest --preset debug
+```


### PR DESCRIPTION
### Motivation
- Improve developer onboarding by providing explicit, platform-specific setup steps and examples. 
- Make Qt discovery and `CMAKE_PREFIX_PATH` handling clearer for common install locations. 
- Clarify build and test commands and fix README formatting for Windows instructions.

### Description
- Add `docs/dev-setup.md` with step-by-step instructions for Linux (Ubuntu/Debian), macOS, and Windows plus examples for setting `CMAKE_PREFIX_PATH`.
- Update `README.md` to link to `docs/dev-setup.md` under a new "Development setup" section. 
- Reformat the Windows build instructions into a fenced code block and tidy overall build/test guidance.

### Testing
- No automated tests were run because the changes are documentation-only and do not affect source or test code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819f7434748321a9175a5696ae9b7d)