### PR TITLE
MWA-01-E: Add .clang-tidy configuration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,20 @@
+---
+Checks: >
+  bugprone-*,
+  cppcoreguidelines-*,
+  modernize-*,
+  performance-*,
+  readability-*,
+  google-*,
+  misc-*,
+  -cppcoreguidelines-owning-memory,
+  -modernize-use-trailing-return-type,
+  -readability-identifier-length,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -readability-magic-numbers
+
+WarningsAsErrors: ''
+
+HeaderFilterRegex: 'src/.*'
+
+FormatStyle: file


### PR DESCRIPTION
## PR Handoff Summary for Owner

### What Changed
- Added `.clang-tidy` at project root with C++20/Qt-appropriate checks

### Requirement IDs Addressed
- NFR-004 (Maintainability — code quality tooling)

### What to Test (Owner Manual Testing)
- Verify `.clang-tidy` exists at project root
- If clang-tidy is installed: `clang-tidy src/main.cpp` should produce no errors

### What to Focus On
- Disabled checks are Qt-incompatible (owning-memory, trailing-return-type, identifier-length, magic-numbers)
- HeaderFilterRegex scoped to `src/.*` only

### Doxygen Documentation Check
- N/A (config file only)

### Test Results Summary
- N/A (config file only)
- Platforms tested: macOS — config is platform-independent

### Known Issues / Limitations
- WarningsAsErrors is empty (warn-only for now) — can tighten later
- Completes Sprint 1 (MWA-01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)