### PR TITLE
MWA-02 Round 1: Core Logger, Settings Manager, Device Interface

### DIFF
--- a/docs/tasks/sprints.md
+++ b/docs/tasks/sprints.md
@@ -1,0 +1,759 @@
+# MWA Sprint Plan
+
+**Created by:** Lead
+**Date:** 2026-03-22
+
+---
+
+## Sprint Overview
+
+| Sprint | Focus | Phase | Status |
+|--------|-------|-------|--------|
+| Sprint 1 | Development Environment Setup | 0 | COMPLETE |
+| Sprint 2 | Core Architecture & Main Window | 1 | IN PROGRESS |
+| Sprint 3 | Device Control Panels (GUI) | 1 | PLANNED |
+| Sprint 4 | Hardware Abstraction Layer | 2 | PLANNED |
+| Sprint 5 | Hardware Device Drivers | 2 | PLANNED |
+| Sprint 6 | Analysis Module Foundation | 3 | PLANNED |
+
+---
+
+## Sprint 1: Development Environment Setup
+
+**Status:** COMPLETE
+**Task file:** `MWA-01-dev-environment.md`
+
+| Task | Description | Status |
+|------|-------------|--------|
+| MWA-01-A | CMake project foundation | DONE |
+| MWA-01-B | CI/CD pipeline (matrix) | DONE |
+| MWA-01-C | Directory structure | DONE |
+| MWA-01-D | .clang-format | DONE |
+| MWA-01-E | .clang-tidy | DONE |
+| MWA-01-F | Qt Test skeleton | DONE |
+| MWA-01-G | Doxyfile | DONE |
+
+---
+
+## Sprint 2: Core Architecture & Main Window
+
+**Goal:** Establish the application shell — main window, logging, settings, and core abstractions that all subsequent features plug into.
+**Branch:** `MWA-02-Core-Architecture`
+**Depends on:** Sprint 1
+
+### MWA-02-A: Core Logger
+
+```
+TASK: MWA-02-A
+REQUIREMENT: GUI-REQ-009, NFR-004
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Create a singleton Logger class in src/core/ that wraps Qt message handling.
+
+  - src/core/logger.h / logger.cpp
+  - Singleton accessed via Logger::instance()
+  - Methods: logInfo(), logWarning(), logError(), logDebug()
+  - Each log entry stores: timestamp, severity, source, message
+  - Emits a Qt signal newLogEntry(const LogEntry&) so GUI can subscribe
+  - LogEntry struct: timestamp (QDateTime), severity (enum), source (QString),
+    message (QString)
+  - Thread-safe (QMutex)
+  - Installs a custom Qt message handler (qInstallMessageHandler) so qDebug/
+    qWarning/qCritical route through the logger
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Logger::instance().logInfo("test") compiles and works
+  - Signal newLogEntry emitted on every log call
+  - Thread-safe (can be called from worker threads)
+  - All public APIs have Doxygen comments
+  - Builds with zero warnings
+DEPENDENCIES: MWA-01-A
+PRIORITY: HIGH
+```
+
+### MWA-02-B: Settings Manager
+
+```
+TASK: MWA-02-B
+REQUIREMENT: GUI-REQ-010, NFR-004
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Create a SettingsManager class in src/core/ wrapping QSettings.
+
+  - src/core/settings_manager.h / settings_manager.cpp
+  - Singleton accessed via SettingsManager::instance()
+  - Groups settings by device: "LED", "Pump", "Camera", etc.
+  - Methods: setValue(group, key, QVariant), value(group, key, default),
+    saveAll(), loadAll()
+  - Uses QSettings with INI format for cross-platform consistency
+  - Emits settingChanged(group, key, value) signal
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Can save/restore values across app restarts
+  - Groups isolate device settings
+  - Signal emitted on change
+  - All public APIs have Doxygen comments
+  - Builds with zero warnings
+DEPENDENCIES: MWA-01-A
+PRIORITY: HIGH
+```
+
+### MWA-02-C: Device Interface (Abstract Base)
+
+```
+TASK: MWA-02-C
+REQUIREMENT: HW-REQ-001, NFR-004, NFR-007
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Define the abstract device interface in src/hardware/.
+
+  - src/hardware/device_interface.h
+  - Pure virtual class DeviceInterface : public QObject
+  - Enum DeviceState { kDisconnected, kConnecting, kConnected, kError }
+  - Enum DeviceType { kLed, kPump, kSignalGenerator, kNetworkAnalyzer,
+    kCamera, kStage }
+  - Pure virtual methods: connect(), disconnect(), deviceName(),
+    deviceType(), state(), isConnected()
+  - Signals: stateChanged(DeviceState), errorOccurred(QString)
+  - Doxygen documentation mandatory on every method, enum, and enum value
+
+ACCEPTANCE CRITERIA:
+  - DeviceInterface is a pure abstract class (cannot be instantiated)
+  - All enums use kCamelCase values per project convention
+  - Signals declared for state changes and errors
+  - All public APIs have Doxygen comments
+  - Builds with zero warnings
+DEPENDENCIES: MWA-01-A
+PRIORITY: HIGH
+```
+
+### MWA-02-D: Main Window Shell
+
+```
+TASK: MWA-02-D
+REQUIREMENT: GUI-REQ-001, NFR-005
+ASSIGNED TO: SWE
+UX REQUIRED: YES — UX must approve layout BEFORE SWE implements
+STATUS: PLANNED
+DESCRIPTION:
+  Create the main application window in src/app/.
+
+  - src/app/main_window.h / main_window.cpp
+  - Class MainWindow : public QMainWindow
+  - Menu bar with: File (Exit), View (toggle panels), Help (About)
+  - Toolbar with placeholder icons
+  - Central widget: QStackedWidget or QSplitter as workspace area
+  - Status bar showing "Ready" by default
+  - Left dock area: reserved for device panels (empty for now)
+  - Bottom dock area: reserved for log panel (empty for now)
+  - Update src/main.cpp to create and show MainWindow
+  - Window title: "MWA — Microfluidics Workstation Automation"
+  - Minimum size: 1024x768
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Application launches and shows the main window
+  - Menu bar, toolbar, status bar visible
+  - Window title correct
+  - Dock areas exist (left and bottom)
+  - All public APIs have Doxygen comments
+  - Builds with zero warnings on both platforms
+DEPENDENCIES: MWA-02-A, MWA-02-B
+PRIORITY: HIGH
+```
+
+### MWA-02-E: Log Panel Widget
+
+```
+TASK: MWA-02-E
+REQUIREMENT: GUI-REQ-009
+ASSIGNED TO: SWE
+UX REQUIRED: YES
+STATUS: PLANNED
+DESCRIPTION:
+  Create a log panel widget in src/gui/widgets/ that displays log entries.
+
+  - src/gui/widgets/log_panel.h / log_panel.cpp
+  - Class LogPanel : public QDockWidget
+  - Contains a QTableView or QListView displaying log entries
+  - Columns: Timestamp, Severity (with color), Source, Message
+  - Connects to Logger::instance().newLogEntry signal
+  - Filter by severity (combo box or checkboxes)
+  - Clear button
+  - Auto-scroll to latest entry
+  - Integrate into MainWindow bottom dock
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Log entries appear in real-time
+  - Severity filtering works
+  - Clear button works
+  - Auto-scroll works
+  - Doxygen complete
+  - Zero warnings
+DEPENDENCIES: MWA-02-A, MWA-02-D
+PRIORITY: MEDIUM
+```
+
+### MWA-02-F: Device Status Dashboard
+
+```
+TASK: MWA-02-F
+REQUIREMENT: GUI-REQ-007
+ASSIGNED TO: SWE
+UX REQUIRED: YES
+STATUS: PLANNED
+DESCRIPTION:
+  Create a device status dashboard widget in src/gui/widgets/.
+
+  - src/gui/widgets/device_status_dashboard.h / .cpp
+  - Class DeviceStatusDashboard : public QWidget
+  - Displays a row/grid of device status indicators
+  - Each device shows: icon, name, state (colored indicator)
+  - States: Disconnected (gray), Connecting (yellow), Connected (green),
+    Error (red)
+  - Observes DeviceInterface::stateChanged signals
+  - Initially shows all 6 device types as "Disconnected"
+  - Integrate into MainWindow (toolbar area or top of central widget)
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - All 6 device types shown with correct names
+  - Color-coded state indicators
+  - Doxygen complete
+  - Zero warnings
+DEPENDENCIES: MWA-02-C, MWA-02-D
+PRIORITY: MEDIUM
+```
+
+**Dependency graph:**
+```
+MWA-02-A (Logger)         MWA-02-B (Settings)    MWA-02-C (DeviceInterface)
+   │                         │                       │
+   ├─────────────────────────┤                       │
+   │                         │                       │
+   └──→ MWA-02-D (MainWindow) ←─────────────────────┘
+            │                                        │
+            ├──→ MWA-02-E (LogPanel)                 │
+            └──→ MWA-02-F (DeviceStatusDashboard) ←──┘
+```
+
+**Execution order:**
+- Round 1 (parallel): MWA-02-A, MWA-02-B, MWA-02-C
+- Round 2: MWA-02-D (needs UX approval first)
+- Round 3 (parallel): MWA-02-E, MWA-02-F
+
+---
+
+## Sprint 3: Device Control Panels (GUI)
+
+**Goal:** Build the GUI panels for each hardware device using mock controllers. No real hardware yet.
+**Branch:** `MWA-03-Device-Panels`
+**Depends on:** Sprint 2
+
+### MWA-03-A: Mock Device Controllers
+
+```
+TASK: MWA-03-A
+REQUIREMENT: HW-REQ-001, NFR-004
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Create mock implementations of DeviceInterface for all 6 device types.
+  These allow GUI development without real hardware.
+
+  For each device (LED, Pump, SignalGenerator, NetworkAnalyzer, Camera, Stage):
+  - src/hardware/<device>/mock_<device>_controller.h / .cpp
+  - Implements DeviceInterface
+  - connect() sets state to kConnected after a simulated delay (QTimer 500ms)
+  - disconnect() sets state to kDisconnected
+  - Device-specific mock methods return sensible defaults
+  - Emits stateChanged signals appropriately
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - All 6 mock controllers compile and implement DeviceInterface
+  - connect()/disconnect() cycle works with signals
+  - Builds with zero warnings
+  - All public APIs documented
+DEPENDENCIES: MWA-02-C
+PRIORITY: HIGH
+```
+
+### MWA-03-B: LED Control Panel
+
+```
+TASK: MWA-03-B
+REQUIREMENT: GUI-REQ-002
+ASSIGNED TO: SWE
+UX REQUIRED: YES
+STATUS: PLANNED
+DESCRIPTION:
+  Create LED control panel in src/gui/panels/.
+
+  - src/gui/panels/led_panel.h / .cpp
+  - Class LedPanel : public QDockWidget
+  - Controls: On/Off toggle button, intensity slider (0-100%), status indicator
+  - Connects to DeviceInterface (accepts any LED controller)
+  - Displays current state from mock controller
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Toggle switches LED on/off via controller
+  - Slider adjusts intensity
+  - Status indicator reflects device state
+  - Works with MockLedController
+  - Doxygen complete, zero warnings
+DEPENDENCIES: MWA-03-A, MWA-02-D
+PRIORITY: HIGH
+```
+
+### MWA-03-C: Syringe Pump Control Panel
+
+```
+TASK: MWA-03-C
+REQUIREMENT: GUI-REQ-003
+ASSIGNED TO: SWE
+UX REQUIRED: YES
+STATUS: PLANNED
+DESCRIPTION:
+  Create syringe pump control panel in src/gui/panels/.
+
+  - src/gui/panels/pump_panel.h / .cpp
+  - Controls: flow rate input (QDoubleSpinBox), volume input, start/stop
+    buttons, refill button, current position display
+  - Units: µL/min for flow rate, µL for volume
+  - Connects to DeviceInterface
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Flow rate and volume inputs validated
+  - Start/stop/refill buttons functional with mock
+  - Current state displayed
+  - Doxygen complete, zero warnings
+DEPENDENCIES: MWA-03-A, MWA-02-D
+PRIORITY: HIGH
+```
+
+### MWA-03-D: Signal Generator / Network Analyzer Panel
+
+```
+TASK: MWA-03-D
+REQUIREMENT: GUI-REQ-004
+ASSIGNED TO: SWE
+UX REQUIRED: YES
+STATUS: PLANNED
+DESCRIPTION:
+  Create frequency/signal control panel in src/gui/panels/.
+
+  - src/gui/panels/signal_panel.h / .cpp
+  - Controls: frequency input (Hz/kHz/MHz), amplitude input, waveform selector
+    (sine/square/triangle), enable/disable output, sweep config (start/stop/step)
+  - S-parameter display area (placeholder QLabel or QChartView)
+  - Connects to DeviceInterface
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Frequency/amplitude inputs with unit selectors
+  - Waveform dropdown
+  - Output enable/disable
+  - Works with mock controller
+  - Doxygen complete, zero warnings
+DEPENDENCIES: MWA-03-A, MWA-02-D
+PRIORITY: HIGH
+```
+
+### MWA-03-E: Camera Control Panel
+
+```
+TASK: MWA-03-E
+REQUIREMENT: GUI-REQ-005
+ASSIGNED TO: SWE
+UX REQUIRED: YES
+STATUS: PLANNED
+DESCRIPTION:
+  Create camera control panel in src/gui/panels/.
+
+  - src/gui/panels/camera_panel.h / .cpp
+  - Controls: exposure (QDoubleSpinBox), gain, ROI settings, single capture
+    button, continuous capture toggle, batch capture (count + interval)
+  - Image preview area (QLabel with scaled QPixmap placeholder)
+  - Connects to DeviceInterface
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Parameter inputs validated
+  - Capture buttons functional with mock
+  - Preview area shows placeholder image
+  - Doxygen complete, zero warnings
+DEPENDENCIES: MWA-03-A, MWA-02-D
+PRIORITY: HIGH
+```
+
+### MWA-03-F: XYZ Stage Control Panel
+
+```
+TASK: MWA-03-F
+REQUIREMENT: GUI-REQ-006
+ASSIGNED TO: SWE
+UX REQUIRED: YES
+STATUS: PLANNED
+DESCRIPTION:
+  Create XYZ stage control panel in src/gui/panels/.
+
+  - src/gui/panels/stage_panel.h / .cpp
+  - Controls: jog buttons (X+/X-/Y+/Y-/Z+/Z-), step size selector,
+    absolute position inputs (X/Y/Z), Go To button, Home button,
+    current position display (read-only)
+  - Speed control (QSlider or QSpinBox)
+  - Connects to DeviceInterface
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Jog buttons send relative moves via controller
+  - Absolute positioning works
+  - Home button functional
+  - Current position updates from mock
+  - Doxygen complete, zero warnings
+DEPENDENCIES: MWA-03-A, MWA-02-D
+PRIORITY: HIGH
+```
+
+**Dependency graph:**
+```
+MWA-03-A (Mock Controllers)
+   │
+   ├──→ MWA-03-B (LED Panel)
+   ├──→ MWA-03-C (Pump Panel)
+   ├──→ MWA-03-D (Signal Panel)
+   ├──→ MWA-03-E (Camera Panel)
+   └──→ MWA-03-F (Stage Panel)
+```
+
+**Execution order:**
+- Round 1: MWA-03-A (mock controllers)
+- Round 2 (parallel): MWA-03-B, C, D, E, F (all panels — each needs UX first)
+
+---
+
+## Sprint 4: Hardware Abstraction Layer
+
+**Goal:** Build the real communication infrastructure — thread-safe command queuing, error recovery, device discovery.
+**Branch:** `MWA-04-Hardware-Abstraction`
+**Depends on:** Sprint 2
+
+### MWA-04-A: Command Queue System
+
+```
+TASK: MWA-04-A
+REQUIREMENT: HW-REQ-009, NFR-001
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Create a thread-safe command queue for device communication.
+
+  - src/hardware/command_queue.h / .cpp
+  - Class CommandQueue : public QObject
+  - Runs on a dedicated QThread per device
+  - Methods: enqueue(std::function<void()>), clear(), shutdown()
+  - Signals: commandStarted(), commandFinished(), commandFailed(QString)
+  - FIFO ordering, one command at a time per device
+  - Timeout support per command
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Commands execute on worker thread, not GUI thread
+  - Thread-safe enqueue from any thread
+  - Timeout triggers error signal
+  - Clean shutdown without deadlocks
+  - Doxygen complete, zero warnings
+DEPENDENCIES: MWA-02-C
+PRIORITY: HIGH
+```
+
+### MWA-04-B: Device Manager
+
+```
+TASK: MWA-04-B
+REQUIREMENT: HW-REQ-008, HW-REQ-011, NFR-006
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Create a DeviceManager that owns and coordinates all device controllers.
+
+  - src/hardware/device_manager.h / .cpp
+  - Singleton: DeviceManager::instance()
+  - Owns all DeviceInterface instances (real or mock)
+  - Methods: registerDevice(), removeDevice(), device(DeviceType),
+    allDevices(), connectAll(), disconnectAll()
+  - Signals: deviceRegistered, deviceRemoved, deviceStateChanged
+  - Platform check: disable devices whose SDKs are unavailable
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Can register and retrieve devices by type
+  - connectAll()/disconnectAll() work
+  - Platform-unavailable devices reported
+  - Doxygen complete, zero warnings
+DEPENDENCIES: MWA-02-C, MWA-04-A
+PRIORITY: HIGH
+```
+
+### MWA-04-C: Error Recovery Framework
+
+```
+TASK: MWA-04-C
+REQUIREMENT: HW-REQ-010, NFR-006
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Create error recovery utilities for device communication.
+
+  - src/hardware/error_handler.h / .cpp
+  - Retry logic with configurable attempts and backoff
+  - Timeout handling with QTimer
+  - Disconnection detection and auto-reconnect option
+  - Emits signals for GUI notification
+  - Integrates with Logger
+  - Doxygen documentation mandatory
+
+ACCEPTANCE CRITERIA:
+  - Retry logic configurable (count, delay)
+  - Timeout triggers error path
+  - Disconnection detected and reported
+  - Logs all errors via Logger
+  - Doxygen complete, zero warnings
+DEPENDENCIES: MWA-02-A, MWA-04-A
+PRIORITY: MEDIUM
+```
+
+**Execution order:**
+- Round 1: MWA-04-A
+- Round 2 (parallel): MWA-04-B, MWA-04-C
+
+---
+
+## Sprint 5: Hardware Device Drivers
+
+**Goal:** Implement real device controllers using vendor SDKs. Each driver is independent.
+**Branch:** `MWA-05-Device-Drivers`
+**Depends on:** Sprint 4
+
+### MWA-05-A: LED Driver (Serial)
+
+```
+TASK: MWA-05-A
+REQUIREMENT: HW-REQ-002
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Implement real LED controller using QSerialPort.
+
+  - src/hardware/led/led_controller.h / .cpp
+  - Implements DeviceInterface
+  - Uses QSerialPort for USB/serial communication
+  - Commands: power on/off, set intensity (0-100%)
+  - Uses CommandQueue for thread-safe I/O
+  - Doxygen documentation mandatory
+
+DEPENDENCIES: MWA-04-A, MWA-04-B
+PRIORITY: HIGH
+```
+
+### MWA-05-B: Syringe Pump Driver (Cetoni SDK)
+
+```
+TASK: MWA-05-B
+REQUIREMENT: HW-REQ-003
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Implement syringe pump controller using Cetoni Nemesys SDK.
+
+  - src/hardware/pump/pump_controller.h / .cpp
+  - Wraps Cetoni SDK calls behind DeviceInterface
+  - Platform-conditional: only available if SDK is found by CMake
+  - Uses CommandQueue for thread-safe I/O
+  - Doxygen documentation mandatory
+
+DEPENDENCIES: MWA-04-A, MWA-04-B
+PRIORITY: HIGH
+```
+
+### MWA-05-C: Frequency Generator Driver (SCPI)
+
+```
+TASK: MWA-05-C
+REQUIREMENT: HW-REQ-004
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Implement frequency generator controller using SCPI over serial/VISA.
+
+  - src/hardware/signal_generator/signal_generator_controller.h / .cpp
+  - SCPI command set for frequency, amplitude, waveform, sweep
+  - Uses QSerialPort or NI-VISA wrapper
+  - Doxygen documentation mandatory
+
+DEPENDENCIES: MWA-04-A, MWA-04-B
+PRIORITY: HIGH
+```
+
+### MWA-05-D: Network Analyzer Driver (SCPI)
+
+```
+TASK: MWA-05-D
+REQUIREMENT: HW-REQ-005
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Implement network analyzer controller using SCPI over VISA.
+
+  - src/hardware/signal_generator/network_analyzer_controller.h / .cpp
+  - S-parameter measurement, frequency sweep, trace data retrieval
+  - Doxygen documentation mandatory
+
+DEPENDENCIES: MWA-04-A, MWA-04-B
+PRIORITY: HIGH
+```
+
+### MWA-05-E: Camera Driver (Basler Pylon)
+
+```
+TASK: MWA-05-E
+REQUIREMENT: HW-REQ-006
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Implement camera controller using Basler Pylon C++ SDK.
+
+  - src/hardware/camera/camera_controller.h / .cpp
+  - Frame acquisition (single, continuous, batch)
+  - Parameter control (exposure, gain, ROI)
+  - Converts Pylon images to QImage for GUI display
+  - Platform-conditional: only if Pylon SDK found
+  - Doxygen documentation mandatory
+
+DEPENDENCIES: MWA-04-A, MWA-04-B
+PRIORITY: HIGH
+```
+
+### MWA-05-F: XYZ Stage Driver (Serial)
+
+```
+TASK: MWA-05-F
+REQUIREMENT: HW-REQ-007
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Implement XYZ stage controller using serial protocol.
+
+  - src/hardware/stage/stage_controller.h / .cpp
+  - Absolute/relative positioning, homing, speed control
+  - Uses QSerialPort
+  - Doxygen documentation mandatory
+
+DEPENDENCIES: MWA-04-A, MWA-04-B
+PRIORITY: HIGH
+```
+
+**Execution order:**
+- All parallel: MWA-05-A through MWA-05-F (independent drivers)
+
+---
+
+## Sprint 6: Analysis Module Foundation
+
+**Goal:** Build the image analysis pipeline foundation.
+**Branch:** `MWA-06-Analysis`
+**Depends on:** Sprint 3 (camera panel), Sprint 5 (camera driver)
+
+### MWA-06-A: Image Batch Manager
+
+```
+TASK: MWA-06-A
+REQUIREMENT: ANA-REQ-001
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Create image batch loading and management in src/analysis/.
+
+  - src/analysis/image_batch.h / .cpp
+  - Load, organize, and navigate batches of images
+  - Support common formats (PNG, TIFF, BMP)
+  - Thumbnail generation
+  - Doxygen documentation mandatory
+
+DEPENDENCIES: MWA-03-E
+PRIORITY: HIGH
+```
+
+### MWA-06-B: Particle Detection
+
+```
+TASK: MWA-06-B
+REQUIREMENT: ANA-REQ-002
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Implement particle detection algorithms in src/analysis/.
+
+  - src/analysis/particle_detector.h / .cpp
+  - Detect particles in microscopy images
+  - Output: list of particle positions and sizes
+  - May use OpenCV if available, or custom implementation
+  - Doxygen documentation mandatory
+
+DEPENDENCIES: MWA-06-A
+PRIORITY: HIGH
+```
+
+### MWA-06-C: Data Export
+
+```
+TASK: MWA-06-C
+REQUIREMENT: ANA-REQ-007
+ASSIGNED TO: SWE
+STATUS: PLANNED
+DESCRIPTION:
+  Implement analysis result export in src/analysis/.
+
+  - src/analysis/data_exporter.h / .cpp
+  - Export to CSV, annotated images, summary reports
+  - Configurable output directory
+  - Doxygen documentation mandatory
+
+DEPENDENCIES: MWA-06-B
+PRIORITY: MEDIUM
+```
+
+**Execution order:**
+- Round 1: MWA-06-A
+- Round 2: MWA-06-B
+- Round 3: MWA-06-C
+
+---
+
+## Agent Parallelism Guide
+
+For running agents in parallel, use these groupings:
+
+| Sprint | Parallel Group | Tasks |
+|--------|---------------|-------|
+| 1 | Remaining | MWA-01-E |
+| 2 | Round 1 | MWA-02-A, MWA-02-B, MWA-02-C |
+| 2 | Round 2 | MWA-02-D (needs UX) |
+| 2 | Round 3 | MWA-02-E, MWA-02-F |
+| 3 | Round 1 | MWA-03-A |
+| 3 | Round 2 | MWA-03-B, C, D, E, F (all need UX) |
+| 4 | Round 1 | MWA-04-A |
+| 4 | Round 2 | MWA-04-B, MWA-04-C |
+| 5 | Round 1 | MWA-05-A, B, C, D, E, F (all parallel) |
+| 6 | Round 1 | MWA-06-A |
+| 6 | Round 2 | MWA-06-B |
+| 6 | Round 3 | MWA-06-C |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,11 @@
+add_subdirectory(core)
+add_subdirectory(hardware)
+
 add_executable(MWA main.cpp)
 
 target_link_libraries(MWA PRIVATE
+  MwaCore
+  MwaHardware
   Qt6::Core
   Qt6::Gui
   Qt6::Widgets

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(MwaCore STATIC
+  logger.h
+  logger.cpp
+  settings_manager.h
+  settings_manager.cpp
+)
+
+target_include_directories(MwaCore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+target_link_libraries(MwaCore PUBLIC Qt6::Core)

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -1,0 +1,81 @@
+/**
+ * @file logger.cpp
+ * @brief Implementation of the singleton Logger class.
+ * @author MWA Team
+ * @date 2026-03-22
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#include "logger.h"
+
+#include <QMutexLocker>
+
+namespace mwa::core {
+
+Logger::Logger() {
+  qRegisterMetaType<LogEntry>("mwa::core::LogEntry");
+  qInstallMessageHandler(qtMessageHandler);
+}
+
+Logger& Logger::instance() {
+  static Logger logger;
+  return logger;
+}
+
+void Logger::logInfo(const QString& message, const QString& source) {
+  log(LogSeverity::kInfo, message, source);
+}
+
+void Logger::logWarning(const QString& message,
+                        const QString& source) {
+  log(LogSeverity::kWarning, message, source);
+}
+
+void Logger::logError(const QString& message,
+                      const QString& source) {
+  log(LogSeverity::kError, message, source);
+}
+
+void Logger::logDebug(const QString& message,
+                      const QString& source) {
+  log(LogSeverity::kDebug, message, source);
+}
+
+void Logger::log(LogSeverity severity, const QString& message,
+                 const QString& source) {
+  QMutexLocker locker(&mutex_);
+  LogEntry entry{QDateTime::currentDateTime(), severity, source,
+                 message};
+  emit newLogEntry(entry);
+}
+
+void Logger::qtMessageHandler(QtMsgType type,
+                              const QMessageLogContext& context,
+                              const QString& msg) {
+  LogSeverity severity = LogSeverity::kDebug;
+  switch (type) {
+    case QtDebugMsg:
+      severity = LogSeverity::kDebug;
+      break;
+    case QtInfoMsg:
+      severity = LogSeverity::kInfo;
+      break;
+    case QtWarningMsg:
+      severity = LogSeverity::kWarning;
+      break;
+    case QtCriticalMsg:
+    case QtFatalMsg:
+      severity = LogSeverity::kError;
+      break;
+  }
+
+  QString source;
+  if (context.category != nullptr) {
+    source = QString::fromUtf8(context.category);
+  }
+
+  instance().log(severity, msg, source);
+}
+
+}  // namespace mwa::core

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -1,0 +1,156 @@
+/**
+ * @file logger.h
+ * @brief Singleton logger wrapping Qt message handling for the MWA system.
+ * @author MWA Team
+ * @date 2026-03-22
+ *
+ * Provides a centralized, thread-safe logging facility that intercepts
+ * Qt debug/warning/critical messages and emits them as structured
+ * LogEntry objects via a Qt signal for GUI consumption.
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <QDateTime>
+#include <QMutex>
+#include <QObject>
+#include <QString>
+
+namespace mwa::core {
+
+/**
+ * @enum LogSeverity
+ * @brief Severity level for a log entry.
+ */
+enum class LogSeverity {
+  kDebug,    ///< Debug-level information.
+  kInfo,     ///< Informational message.
+  kWarning,  ///< Warning — potential issue.
+  kError     ///< Error — something failed.
+};
+
+/**
+ * @struct LogEntry
+ * @brief A single structured log record.
+ */
+struct LogEntry {
+  QDateTime timestamp;   ///< When the entry was created.
+  LogSeverity severity;  ///< Severity level.
+  QString source;        ///< Originating component or category.
+  QString message;       ///< Log message text.
+};
+
+/**
+ * @class Logger
+ * @brief Thread-safe singleton logger with Qt signal notification.
+ *
+ * Logger installs a custom Qt message handler so that qDebug(),
+ * qWarning(), and qCritical() are routed through it. Each log call
+ * creates a LogEntry and emits the newLogEntry() signal so that GUI
+ * components (e.g. a log panel) can subscribe.
+ *
+ * @note All public logging methods are thread-safe.
+ *
+ * @see LogEntry
+ * @see LogSeverity
+ */
+class Logger : public QObject {
+  Q_OBJECT
+  Q_ENUM(LogSeverity)
+
+ public:
+  /**
+   * @brief Access the singleton Logger instance.
+   *
+   * The instance is created on first call and lives until application
+   * exit. The custom Qt message handler is installed on first call.
+   *
+   * @return Reference to the singleton Logger.
+   */
+  static Logger& instance();
+
+  /**
+   * @brief Log an informational message.
+   *
+   * @param message The message text.
+   * @param source  Optional originating component name.
+   */
+  void logInfo(const QString& message,
+               const QString& source = QString());
+
+  /**
+   * @brief Log a warning message.
+   *
+   * @param message The message text.
+   * @param source  Optional originating component name.
+   */
+  void logWarning(const QString& message,
+                  const QString& source = QString());
+
+  /**
+   * @brief Log an error message.
+   *
+   * @param message The message text.
+   * @param source  Optional originating component name.
+   */
+  void logError(const QString& message,
+                const QString& source = QString());
+
+  /**
+   * @brief Log a debug message.
+   *
+   * @param message The message text.
+   * @param source  Optional originating component name.
+   */
+  void logDebug(const QString& message,
+                const QString& source = QString());
+
+  // Non-copyable, non-movable singleton.
+  Logger(const Logger&) = delete;
+  Logger& operator=(const Logger&) = delete;
+  Logger(Logger&&) = delete;
+  Logger& operator=(Logger&&) = delete;
+
+ signals:
+  /**
+   * @brief Emitted for every new log entry.
+   *
+   * @param entry The structured log record.
+   */
+  void newLogEntry(const mwa::core::LogEntry& entry);
+
+ private:
+  /**
+   * @brief Private constructor — use instance() instead.
+   */
+  Logger();
+
+  /**
+   * @brief Create a LogEntry and emit newLogEntry().
+   *
+   * @param severity The severity level.
+   * @param message  The message text.
+   * @param source   The originating component.
+   */
+  void log(LogSeverity severity, const QString& message,
+           const QString& source);
+
+  /**
+   * @brief Custom Qt message handler installed via qInstallMessageHandler.
+   *
+   * @param type    The Qt message type.
+   * @param context The message context (file, line, function).
+   * @param msg     The formatted message string.
+   */
+  static void qtMessageHandler(QtMsgType type,
+                                const QMessageLogContext& context,
+                                const QString& msg);
+
+  QMutex mutex_;  ///< Guards log() for thread safety.
+};
+
+}  // namespace mwa::core
+
+Q_DECLARE_METATYPE(mwa::core::LogEntry)

--- a/src/core/settings_manager.cpp
+++ b/src/core/settings_manager.cpp
@@ -1,0 +1,50 @@
+/**
+ * @file settings_manager.cpp
+ * @brief Implementation of the singleton SettingsManager class.
+ * @author MWA Team
+ * @date 2026-03-22
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#include "settings_manager.h"
+
+namespace mwa::core {
+
+SettingsManager::SettingsManager()
+    : settings_(QSettings::IniFormat, QSettings::UserScope,
+                QStringLiteral("MWA"),
+                QStringLiteral("MicrofluidicsWorkstation")) {}
+
+SettingsManager& SettingsManager::instance() {
+  static SettingsManager manager;
+  return manager;
+}
+
+void SettingsManager::setValue(const QString& group,
+                               const QString& key,
+                               const QVariant& value) {
+  QString full_key = group + "/" + key;
+  QVariant old_value = settings_.value(full_key);
+  settings_.setValue(full_key, value);
+  if (old_value != value) {
+    emit settingChanged(group, key, value);
+  }
+}
+
+QVariant SettingsManager::value(const QString& group,
+                                const QString& key,
+                                const QVariant& default_value) const {
+  QString full_key = group + "/" + key;
+  return settings_.value(full_key, default_value);
+}
+
+void SettingsManager::saveAll() {
+  settings_.sync();
+}
+
+void SettingsManager::loadAll() {
+  settings_.sync();
+}
+
+}  // namespace mwa::core

--- a/src/core/settings_manager.h
+++ b/src/core/settings_manager.h
@@ -1,0 +1,107 @@
+/**
+ * @file settings_manager.h
+ * @brief Singleton settings manager wrapping QSettings with INI format.
+ * @author MWA Team
+ * @date 2026-03-22
+ *
+ * Provides a centralized, group-based settings facility that persists
+ * configuration using QSettings in INI format for cross-platform
+ * consistency.
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QSettings>
+#include <QString>
+#include <QVariant>
+
+namespace mwa::core {
+
+/**
+ * @class SettingsManager
+ * @brief Singleton that manages application settings grouped by device.
+ *
+ * SettingsManager wraps QSettings with INI format and organizes
+ * settings into groups (e.g. "LED", "Pump", "Camera"). It emits a
+ * signal whenever a setting changes, allowing GUI components to react.
+ *
+ * @note Settings are written through immediately via QSettings::sync()
+ *       when saveAll() is called.
+ *
+ * @see QSettings
+ */
+class SettingsManager : public QObject {
+  Q_OBJECT
+
+ public:
+  /**
+   * @brief Access the singleton SettingsManager instance.
+   *
+   * @return Reference to the singleton SettingsManager.
+   */
+  static SettingsManager& instance();
+
+  /**
+   * @brief Set a value within a device settings group.
+   *
+   * If the new value differs from the existing value, the
+   * settingChanged() signal is emitted.
+   *
+   * @param group The settings group name (e.g. "LED", "Pump").
+   * @param key   The setting key within the group.
+   * @param value The value to store.
+   */
+  void setValue(const QString& group, const QString& key,
+                const QVariant& value);
+
+  /**
+   * @brief Retrieve a value from a device settings group.
+   *
+   * @param group        The settings group name.
+   * @param key          The setting key within the group.
+   * @param default_value Value returned if the key does not exist.
+   * @return The stored value, or @p default_value if not found.
+   */
+  QVariant value(const QString& group, const QString& key,
+                 const QVariant& default_value = QVariant()) const;
+
+  /**
+   * @brief Flush all pending settings to persistent storage.
+   */
+  void saveAll();
+
+  /**
+   * @brief Reload all settings from persistent storage.
+   */
+  void loadAll();
+
+  // Non-copyable, non-movable singleton.
+  SettingsManager(const SettingsManager&) = delete;
+  SettingsManager& operator=(const SettingsManager&) = delete;
+  SettingsManager(SettingsManager&&) = delete;
+  SettingsManager& operator=(SettingsManager&&) = delete;
+
+ signals:
+  /**
+   * @brief Emitted when a setting value changes.
+   *
+   * @param group The settings group that was modified.
+   * @param key   The key that was modified.
+   * @param value The new value.
+   */
+  void settingChanged(const QString& group, const QString& key,
+                      const QVariant& value);
+
+ private:
+  /**
+   * @brief Private constructor — use instance() instead.
+   */
+  SettingsManager();
+
+  QSettings settings_;  ///< Underlying INI-format QSettings store.
+};
+
+}  // namespace mwa::core

--- a/src/hardware/CMakeLists.txt
+++ b/src/hardware/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(MwaHardware INTERFACE)
+
+target_include_directories(MwaHardware INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+target_link_libraries(MwaHardware INTERFACE Qt6::Core)
+
+target_sources(MwaHardware INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR}/device_interface.h
+)

--- a/src/hardware/device_interface.h
+++ b/src/hardware/device_interface.h
@@ -1,0 +1,143 @@
+/**
+ * @file device_interface.h
+ * @brief Abstract base class defining the interface for all hardware devices.
+ * @author MWA Team
+ * @date 2026-03-22
+ *
+ * This file defines the pure abstract DeviceInterface class, which all
+ * hardware device implementations must inherit and implement.
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+namespace mwa::hardware {
+
+/**
+ * @class DeviceInterface
+ * @brief Pure abstract base class for all hardware devices in the MWA system.
+ *
+ * DeviceInterface establishes the contract every hardware driver must
+ * fulfil. It inherits from QObject to participate in Qt's signal/slot
+ * mechanism and exposes signals for state transitions and error reporting.
+ * Concrete subclasses must implement every pure virtual method.
+ *
+ * @note Because DeviceInterface inherits QObject it cannot be copied.
+ *       Subclasses must accept a QObject parent pointer and forward it
+ *       to this class's constructor.
+ *
+ * @see DeviceState
+ * @see DeviceType
+ */
+class DeviceInterface : public QObject {
+  Q_OBJECT
+
+ public:
+  /**
+   * @enum DeviceState
+   * @brief Represents the current connection state of a hardware device.
+   */
+  enum class DeviceState {
+    kDisconnected,  ///< Device is not connected.
+    kConnecting,    ///< Connection attempt is in progress.
+    kConnected,     ///< Device is connected and ready.
+    kError          ///< Device encountered an error.
+  };
+  Q_ENUM(DeviceState)
+
+  /**
+   * @enum DeviceType
+   * @brief Identifies the category of a hardware device.
+   */
+  enum class DeviceType {
+    kLed,              ///< LED illumination source.
+    kPump,             ///< Syringe pump.
+    kSignalGenerator,  ///< Signal/waveform generator.
+    kNetworkAnalyzer,  ///< Network/impedance analyzer.
+    kCamera,           ///< Imaging camera.
+    kStage             ///< Motorized XYZ translation stage.
+  };
+  Q_ENUM(DeviceType)
+
+  /**
+   * @brief Virtual destructor.
+   */
+  ~DeviceInterface() override = default;
+
+  /**
+   * @brief Initiate an asynchronous connection to the physical device.
+   *
+   * Implementations should transition the device state to
+   * DeviceState::kConnecting immediately and emit stateChanged(). On
+   * success the state becomes DeviceState::kConnected; on failure it
+   * becomes DeviceState::kError and errorOccurred() is emitted.
+   */
+  virtual void connectDevice() = 0;
+
+  /**
+   * @brief Initiate a graceful disconnection from the physical device.
+   *
+   * After calling this method the device state must eventually reach
+   * DeviceState::kDisconnected and stateChanged() must be emitted.
+   */
+  virtual void disconnectDevice() = 0;
+
+  /**
+   * @brief Return a human-readable name identifying this device instance.
+   *
+   * @return A non-empty QString with the device display name.
+   */
+  [[nodiscard]] virtual QString deviceName() const = 0;
+
+  /**
+   * @brief Return the category of this device.
+   *
+   * @return The DeviceType enum value for this device.
+   */
+  [[nodiscard]] virtual DeviceType deviceType() const = 0;
+
+  /**
+   * @brief Return the current connection state of this device.
+   *
+   * @return The DeviceState enum value representing the current state.
+   */
+  [[nodiscard]] virtual DeviceState state() const = 0;
+
+  /**
+   * @brief Convenience query for whether the device is fully connected.
+   *
+   * @return @c true if the device state is DeviceState::kConnected.
+   */
+  [[nodiscard]] virtual bool isConnected() const = 0;
+
+ signals:
+  /**
+   * @brief Emitted whenever the device connection state changes.
+   *
+   * @param new_state The updated DeviceState value.
+   */
+  void stateChanged(
+      mwa::hardware::DeviceInterface::DeviceState new_state);
+
+  /**
+   * @brief Emitted when the device encounters an error.
+   *
+   * @param message A human-readable description of the error.
+   */
+  void errorOccurred(const QString& message);
+
+ protected:
+  /**
+   * @brief Protected constructor — only concrete subclasses may call this.
+   *
+   * @param parent Optional QObject parent for Qt ownership management.
+   */
+  explicit DeviceInterface(QObject* parent = nullptr)
+      : QObject(parent) {}
+};
+
+}  // namespace mwa::hardware

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,3 +6,42 @@ target_link_libraries(tst_smoke PRIVATE
 )
 
 add_test(NAME tst_smoke COMMAND tst_smoke)
+
+# ---------------------------------------------------------------------------
+# Logger tests
+# ---------------------------------------------------------------------------
+add_executable(test_logger test_logger.cpp)
+
+target_link_libraries(test_logger PRIVATE
+  MwaCore
+  Qt6::Core
+  Qt6::Test
+)
+
+add_test(NAME test_logger COMMAND test_logger)
+
+# ---------------------------------------------------------------------------
+# SettingsManager tests
+# ---------------------------------------------------------------------------
+add_executable(test_settings_manager test_settings_manager.cpp)
+
+target_link_libraries(test_settings_manager PRIVATE
+  MwaCore
+  Qt6::Core
+  Qt6::Test
+)
+
+add_test(NAME test_settings_manager COMMAND test_settings_manager)
+
+# ---------------------------------------------------------------------------
+# DeviceInterface tests
+# ---------------------------------------------------------------------------
+add_executable(test_device_interface test_device_interface.cpp)
+
+target_link_libraries(test_device_interface PRIVATE
+  MwaHardware
+  Qt6::Core
+  Qt6::Test
+)
+
+add_test(NAME test_device_interface COMMAND test_device_interface)

--- a/tests/test_device_interface.cpp
+++ b/tests/test_device_interface.cpp
@@ -1,0 +1,287 @@
+/**
+ * @file test_device_interface.cpp
+ * @brief Adversarial tests for mwa::hardware::DeviceInterface.
+ * @date 2026-03-22
+ * @copyright LGPL-3.0-or-later
+ */
+
+#include <QMetaEnum>
+#include <QObject>
+#include <QSignalSpy>
+#include <QString>
+#include <QtTest>
+
+#include "hardware/device_interface.h"
+
+using mwa::hardware::DeviceInterface;
+using DeviceState = DeviceInterface::DeviceState;
+using DeviceType = DeviceInterface::DeviceType;
+
+// ---------------------------------------------------------------------------
+// Minimal concrete implementation used across tests.
+// ---------------------------------------------------------------------------
+class MockDevice : public DeviceInterface {
+  Q_OBJECT
+
+ public:
+  explicit MockDevice(QObject* parent = nullptr)
+      : DeviceInterface(parent),
+        state_(DeviceState::kDisconnected),
+        type_(DeviceType::kLed) {}
+
+  void connectDevice() override {
+    state_ = DeviceState::kConnecting;
+    emit stateChanged(state_);
+    state_ = DeviceState::kConnected;
+    emit stateChanged(state_);
+  }
+
+  void disconnectDevice() override {
+    state_ = DeviceState::kDisconnected;
+    emit stateChanged(state_);
+  }
+
+  [[nodiscard]] QString deviceName() const override { return name_; }
+
+  [[nodiscard]] DeviceType deviceType() const override { return type_; }
+
+  [[nodiscard]] DeviceState state() const override { return state_; }
+
+  [[nodiscard]] bool isConnected() const override {
+    return state_ == DeviceState::kConnected;
+  }
+
+  // Helpers to drive the device for testing.
+  void setName(const QString& n) { name_ = n; }
+  void setType(DeviceType t) { type_ = t; }
+  void triggerError(const QString& msg) {
+    state_ = DeviceState::kError;
+    emit stateChanged(state_);
+    emit errorOccurred(msg);
+  }
+
+ private:
+  DeviceState state_;
+  DeviceType type_;
+  QString name_{QStringLiteral("MockDevice")};
+};
+
+// ---------------------------------------------------------------------------
+// Test class
+// ---------------------------------------------------------------------------
+class TestDeviceInterface : public QObject {
+  Q_OBJECT
+
+ private slots:
+  void test_concreteSubclass_canBeInstantiated();
+  void test_connectDevice_emitsStateChangingThenConnected();
+  void test_disconnectDevice_emitsDisconnected();
+  void test_isConnected_trueAfterConnect();
+  void test_isConnected_falseAfterDisconnect();
+  void test_isConnected_falseInitially();
+  void test_deviceName_returnsSetValue();
+  void test_deviceType_returnsSetType();
+  void test_errorOccurred_signalEmitted();
+  void test_stateChanged_toError_viaHelper();
+  void test_deviceState_enumValues_areDistinct();
+  void test_deviceType_enumValues_areDistinct();
+  void test_deviceState_qEnum_accessible();
+  void test_deviceType_qEnum_accessible();
+  void test_stateChanged_signalCarriesCorrectValue();
+  void test_errorOccurred_signalCarriesMessage();
+  void test_parentOwnership_deviceDeletedWithParent();
+};
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_concreteSubclass_canBeInstantiated() {
+  MockDevice dev;
+  // Verify the object is usable: a virtual call must return a non-null
+  // string (the default name set in the constructor).
+  QVERIFY2(!dev.deviceName().isNull(),
+           "deviceName() must return a valid QString on a live instance");
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_connectDevice_emitsStateChangingThenConnected() {
+  MockDevice dev;
+  QSignalSpy spy(&dev, &DeviceInterface::stateChanged);
+  dev.connectDevice();
+  QCOMPARE(spy.count(), 2);
+  QCOMPARE(qvariant_cast<DeviceState>(spy.at(0).at(0)),
+           DeviceState::kConnecting);
+  QCOMPARE(qvariant_cast<DeviceState>(spy.at(1).at(0)),
+           DeviceState::kConnected);
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_disconnectDevice_emitsDisconnected() {
+  MockDevice dev;
+  dev.connectDevice();
+  QSignalSpy spy(&dev, &DeviceInterface::stateChanged);
+  dev.disconnectDevice();
+  QCOMPARE(spy.count(), 1);
+  QCOMPARE(qvariant_cast<DeviceState>(spy.at(0).at(0)),
+           DeviceState::kDisconnected);
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_isConnected_trueAfterConnect() {
+  MockDevice dev;
+  dev.connectDevice();
+  QVERIFY2(dev.isConnected(), "isConnected() must be true after connectDevice");
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_isConnected_falseAfterDisconnect() {
+  MockDevice dev;
+  dev.connectDevice();
+  dev.disconnectDevice();
+  QVERIFY2(!dev.isConnected(),
+           "isConnected() must be false after disconnectDevice");
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_isConnected_falseInitially() {
+  MockDevice dev;
+  QVERIFY2(!dev.isConnected(), "isConnected() must be false before connect");
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_deviceName_returnsSetValue() {
+  MockDevice dev;
+  dev.setName(QStringLiteral("Pump Alpha"));
+  QCOMPARE(dev.deviceName(), QStringLiteral("Pump Alpha"));
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_deviceType_returnsSetType() {
+  MockDevice dev;
+  dev.setType(DeviceType::kCamera);
+  QCOMPARE(dev.deviceType(), DeviceType::kCamera);
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_errorOccurred_signalEmitted() {
+  MockDevice dev;
+  QSignalSpy spy(&dev, &DeviceInterface::errorOccurred);
+  dev.triggerError(QStringLiteral("timeout"));
+  QCOMPARE(spy.count(), 1);
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_stateChanged_toError_viaHelper() {
+  MockDevice dev;
+  QSignalSpy spy(&dev, &DeviceInterface::stateChanged);
+  dev.triggerError(QStringLiteral("fault"));
+  // triggerError emits stateChanged(kError) then errorOccurred.
+  QVERIFY2(spy.count() >= 1, "stateChanged must fire on error transition");
+  bool saw_error = false;
+  for (int i = 0; i < spy.count(); ++i) {
+    if (qvariant_cast<DeviceState>(spy.at(i).at(0)) ==
+        DeviceState::kError) {
+      saw_error = true;
+    }
+  }
+  QVERIFY2(saw_error, "stateChanged(kError) must be emitted");
+}
+
+// ---------------------------------------------------------------------------
+// Enum integrity: all enum values must differ from one another.
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_deviceState_enumValues_areDistinct() {
+  QList<int> vals{
+      static_cast<int>(DeviceState::kDisconnected),
+      static_cast<int>(DeviceState::kConnecting),
+      static_cast<int>(DeviceState::kConnected),
+      static_cast<int>(DeviceState::kError)};
+  for (int i = 0; i < vals.size(); ++i) {
+    for (int j = i + 1; j < vals.size(); ++j) {
+      QVERIFY2(vals[i] != vals[j],
+               "DeviceState enum values must be distinct");
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_deviceType_enumValues_areDistinct() {
+  QList<int> vals{
+      static_cast<int>(DeviceType::kLed),
+      static_cast<int>(DeviceType::kPump),
+      static_cast<int>(DeviceType::kSignalGenerator),
+      static_cast<int>(DeviceType::kNetworkAnalyzer),
+      static_cast<int>(DeviceType::kCamera),
+      static_cast<int>(DeviceType::kStage)};
+  for (int i = 0; i < vals.size(); ++i) {
+    for (int j = i + 1; j < vals.size(); ++j) {
+      QVERIFY2(vals[i] != vals[j],
+               "DeviceType enum values must be distinct");
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Q_ENUM must make the enum discoverable via QMetaEnum.
+// ---------------------------------------------------------------------------
+static int findEnumInChain(const QMetaObject* mo, const char* name) {
+  while (mo != nullptr) {
+    int idx = mo->indexOfEnumerator(name);
+    if (idx >= 0) return idx;
+    mo = mo->superClass();
+  }
+  return -1;
+}
+
+void TestDeviceInterface::test_deviceState_qEnum_accessible() {
+  int idx = findEnumInChain(&MockDevice::staticMetaObject,
+                            "DeviceState");
+  QVERIFY2(idx >= 0,
+           "DeviceState must be registered via Q_ENUM");
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_deviceType_qEnum_accessible() {
+  int idx = findEnumInChain(&MockDevice::staticMetaObject,
+                            "DeviceType");
+  QVERIFY2(idx >= 0,
+           "DeviceType must be registered via Q_ENUM");
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_stateChanged_signalCarriesCorrectValue() {
+  MockDevice dev;
+  QSignalSpy spy(&dev, &DeviceInterface::stateChanged);
+  dev.connectDevice();
+  // Last emission should be kConnected.
+  QVERIFY(spy.count() > 0);
+  auto last_state =
+      qvariant_cast<DeviceState>(spy.last().at(0));
+  QCOMPARE(last_state, DeviceState::kConnected);
+}
+
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_errorOccurred_signalCarriesMessage() {
+  MockDevice dev;
+  QSignalSpy spy(&dev, &DeviceInterface::errorOccurred);
+  const QString msg = QStringLiteral("communication timeout");
+  dev.triggerError(msg);
+  QCOMPARE(spy.count(), 1);
+  QCOMPARE(spy.at(0).at(0).toString(), msg);
+}
+
+// ---------------------------------------------------------------------------
+// Qt parent ownership: when parent is deleted the device must also be
+// deleted — this verifies proper QObject hierarchy.
+// ---------------------------------------------------------------------------
+void TestDeviceInterface::test_parentOwnership_deviceDeletedWithParent() {
+  auto* parent = new QObject();
+  // Device is owned by parent; casting to DeviceInterface* to verify
+  // it is accessible via the abstract pointer.
+  DeviceInterface* dev = new MockDevice(parent);
+  QVERIFY(dev->parent() == parent);
+  delete parent;  // Must not crash.
+  QVERIFY(true);
+}
+
+// ---------------------------------------------------------------------------
+QTEST_MAIN(TestDeviceInterface)
+#include "test_device_interface.moc"

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -1,0 +1,255 @@
+/**
+ * @file test_logger.cpp
+ * @brief Adversarial tests for mwa::core::Logger.
+ * @date 2026-03-22
+ * @copyright LGPL-3.0-or-later
+ */
+
+#include <QDateTime>
+#include <QList>
+#include <QMutex>
+#include <QObject>
+#include <QSignalSpy>
+#include <QString>
+#include <QThread>
+#include <QtTest>
+
+#include "core/logger.h"
+
+using mwa::core::LogEntry;
+using mwa::core::Logger;
+using mwa::core::LogSeverity;
+
+// ---------------------------------------------------------------------------
+// Helper: captures every newLogEntry emission into a list.
+// ---------------------------------------------------------------------------
+class LogCapture : public QObject {
+  Q_OBJECT
+ public:
+  explicit LogCapture(QObject* parent = nullptr) : QObject(parent) {
+    connect(&Logger::instance(), &Logger::newLogEntry, this,
+            &LogCapture::onEntry, Qt::DirectConnection);
+  }
+
+  void clear() {
+    QMutexLocker lock(&mutex_);
+    entries_.clear();
+  }
+
+  QList<LogEntry> entries() {
+    QMutexLocker lock(&mutex_);
+    return entries_;
+  }
+
+ private slots:
+  void onEntry(const mwa::core::LogEntry& e) {
+    QMutexLocker lock(&mutex_);
+    entries_.append(e);
+  }
+
+ private:
+  QMutex mutex_;
+  QList<LogEntry> entries_;
+};
+
+// ---------------------------------------------------------------------------
+// Test class
+// ---------------------------------------------------------------------------
+class TestLogger : public QObject {
+  Q_OBJECT
+
+ private slots:
+  void initTestCase();
+  void cleanup();
+
+  void test_instance_returnsSameObject();
+  void test_logInfo_emitsSeverityInfo();
+  void test_logWarning_emitsSeverityWarning();
+  void test_logError_emitsSeverityError();
+  void test_logDebug_emitsSeverityDebug();
+  void test_logEntry_carriesCorrectMessage();
+  void test_logEntry_carriesCorrectSource();
+  void test_logEntry_emptySourceIsPreserved();
+  void test_logEntry_timestampIsRecent();
+  void test_qtMessageHandler_qDebugRoutedAsDebug();
+  void test_qtMessageHandler_qWarningRoutedAsWarning();
+  void test_qtMessageHandler_qCriticalRoutedAsError();
+  void test_threadSafety_concurrentLogsAllDelivered();
+
+ private:
+  LogCapture* capture_{nullptr};
+};
+
+// ---------------------------------------------------------------------------
+void TestLogger::initTestCase() {
+  // Touch the singleton once so the message handler is installed.
+  Logger::instance();
+  qRegisterMetaType<LogEntry>("mwa::core::LogEntry");
+}
+
+void TestLogger::cleanup() {
+  // Reset capture between tests.
+  if (capture_) {
+    capture_->clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_instance_returnsSameObject() {
+  Logger* a = &Logger::instance();
+  Logger* b = &Logger::instance();
+  QVERIFY2(a == b, "instance() must return the same address on every call");
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_logInfo_emitsSeverityInfo() {
+  QSignalSpy spy(&Logger::instance(), &Logger::newLogEntry);
+  Logger::instance().logInfo(QStringLiteral("info msg"));
+  QCOMPARE(spy.count(), 1);
+  auto entry = qvariant_cast<LogEntry>(spy.at(0).at(0));
+  QCOMPARE(entry.severity, LogSeverity::kInfo);
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_logWarning_emitsSeverityWarning() {
+  QSignalSpy spy(&Logger::instance(), &Logger::newLogEntry);
+  Logger::instance().logWarning(QStringLiteral("warn msg"));
+  QCOMPARE(spy.count(), 1);
+  auto entry = qvariant_cast<LogEntry>(spy.at(0).at(0));
+  QCOMPARE(entry.severity, LogSeverity::kWarning);
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_logError_emitsSeverityError() {
+  QSignalSpy spy(&Logger::instance(), &Logger::newLogEntry);
+  Logger::instance().logError(QStringLiteral("err msg"));
+  QCOMPARE(spy.count(), 1);
+  auto entry = qvariant_cast<LogEntry>(spy.at(0).at(0));
+  QCOMPARE(entry.severity, LogSeverity::kError);
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_logDebug_emitsSeverityDebug() {
+  QSignalSpy spy(&Logger::instance(), &Logger::newLogEntry);
+  Logger::instance().logDebug(QStringLiteral("dbg msg"));
+  QCOMPARE(spy.count(), 1);
+  auto entry = qvariant_cast<LogEntry>(spy.at(0).at(0));
+  QCOMPARE(entry.severity, LogSeverity::kDebug);
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_logEntry_carriesCorrectMessage() {
+  QSignalSpy spy(&Logger::instance(), &Logger::newLogEntry);
+  const QString expected = QStringLiteral("Hello MWA");
+  Logger::instance().logInfo(expected, QStringLiteral("src"));
+  QCOMPARE(spy.count(), 1);
+  auto entry = qvariant_cast<LogEntry>(spy.at(0).at(0));
+  QCOMPARE(entry.message, expected);
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_logEntry_carriesCorrectSource() {
+  QSignalSpy spy(&Logger::instance(), &Logger::newLogEntry);
+  const QString src = QStringLiteral("LedController");
+  Logger::instance().logInfo(QStringLiteral("msg"), src);
+  QCOMPARE(spy.count(), 1);
+  auto entry = qvariant_cast<LogEntry>(spy.at(0).at(0));
+  QCOMPARE(entry.source, src);
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_logEntry_emptySourceIsPreserved() {
+  QSignalSpy spy(&Logger::instance(), &Logger::newLogEntry);
+  // Call with default (empty) source.
+  Logger::instance().logInfo(QStringLiteral("no source"));
+  QCOMPARE(spy.count(), 1);
+  auto entry = qvariant_cast<LogEntry>(spy.at(0).at(0));
+  QVERIFY2(entry.source.isEmpty(),
+           "source must be empty when none is provided");
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_logEntry_timestampIsRecent() {
+  const QDateTime before = QDateTime::currentDateTime();
+  QSignalSpy spy(&Logger::instance(), &Logger::newLogEntry);
+  Logger::instance().logInfo(QStringLiteral("ts test"));
+  const QDateTime after = QDateTime::currentDateTime();
+  QCOMPARE(spy.count(), 1);
+  auto entry = qvariant_cast<LogEntry>(spy.at(0).at(0));
+  QVERIFY2(entry.timestamp >= before && entry.timestamp <= after,
+           "LogEntry timestamp must fall between before and after the call");
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_qtMessageHandler_qDebugRoutedAsDebug() {
+  QSignalSpy spy(&Logger::instance(), &Logger::newLogEntry);
+  qDebug("qt-debug-route");
+  // qDebug may emit from the default category; we only care about severity.
+  QVERIFY2(spy.count() >= 1, "qDebug must reach the Logger");
+  auto entry = qvariant_cast<LogEntry>(spy.last().at(0));
+  QCOMPARE(entry.severity, LogSeverity::kDebug);
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_qtMessageHandler_qWarningRoutedAsWarning() {
+  QSignalSpy spy(&Logger::instance(), &Logger::newLogEntry);
+  qWarning("qt-warning-route");
+  QVERIFY2(spy.count() >= 1, "qWarning must reach the Logger");
+  auto entry = qvariant_cast<LogEntry>(spy.last().at(0));
+  QCOMPARE(entry.severity, LogSeverity::kWarning);
+}
+
+// ---------------------------------------------------------------------------
+void TestLogger::test_qtMessageHandler_qCriticalRoutedAsError() {
+  QSignalSpy spy(&Logger::instance(), &Logger::newLogEntry);
+  qCritical("qt-critical-route");
+  QVERIFY2(spy.count() >= 1, "qCritical must reach the Logger");
+  auto entry = qvariant_cast<LogEntry>(spy.last().at(0));
+  QCOMPARE(entry.severity, LogSeverity::kError);
+}
+
+// ---------------------------------------------------------------------------
+// Thread-safety: spin up several threads, each logs kIterations messages,
+// and verify all are delivered without crash or message loss.
+// ---------------------------------------------------------------------------
+void TestLogger::test_threadSafety_concurrentLogsAllDelivered() {
+  constexpr int kThreads = 8;
+  constexpr int kIterations = 50;
+  constexpr int kExpected = kThreads * kIterations;
+
+  capture_ = new LogCapture(this);
+  capture_->clear();
+
+  QList<QThread*> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    auto* thread = QThread::create([t]() {
+      for (int i = 0; i < kIterations; ++i) {
+        Logger::instance().logInfo(
+            QStringLiteral("thread %1 msg %2").arg(t).arg(i),
+            QStringLiteral("ThreadTest"));
+      }
+    });
+    threads.append(thread);
+  }
+
+  for (auto* thread : threads) thread->start();
+  for (auto* thread : threads) thread->wait(5000);
+  for (auto* thread : threads) delete thread;
+
+  // Process any pending queued signals.
+  QCoreApplication::processEvents();
+
+  int count = capture_->entries().size();
+  QVERIFY2(count == kExpected,
+           qPrintable(
+               QStringLiteral("Expected %1 log entries, got %2")
+                   .arg(kExpected)
+                   .arg(count)));
+
+  delete capture_;
+  capture_ = nullptr;
+}
+
+// ---------------------------------------------------------------------------
+QTEST_MAIN(TestLogger)
+#include "test_logger.moc"

--- a/tests/test_settings_manager.cpp
+++ b/tests/test_settings_manager.cpp
@@ -1,0 +1,255 @@
+/**
+ * @file test_settings_manager.cpp
+ * @brief Adversarial tests for mwa::core::SettingsManager.
+ * @date 2026-03-22
+ * @copyright LGPL-3.0-or-later
+ */
+
+#include <QObject>
+#include <QSignalSpy>
+#include <QString>
+#include <QTemporaryDir>
+#include <QVariant>
+#include <QtTest>
+
+#include "core/settings_manager.h"
+
+using mwa::core::SettingsManager;
+
+// ---------------------------------------------------------------------------
+// Test class
+// ---------------------------------------------------------------------------
+class TestSettingsManager : public QObject {
+  Q_OBJECT
+
+ private slots:
+  void initTestCase();
+  void init();
+
+  void test_instance_returnsSameObject();
+  void test_setValue_roundTrip_int();
+  void test_setValue_roundTrip_double();
+  void test_setValue_roundTrip_string();
+  void test_setValue_roundTrip_bool();
+  void test_value_returnsDefault_whenKeyMissing();
+  void test_value_returnsStoredValue_notDefault();
+  void test_settingChanged_emittedOnNewValue();
+  void test_settingChanged_notEmitted_onSameValueSetAgain();
+  void test_settingChanged_emittedOnValueChange();
+  void test_settingChanged_signalCarriesGroupKeyValue();
+  void test_differentGroups_isolateSettings();
+  void test_emptyKey_doesNotCrash();
+  void test_emptyGroup_doesNotCrash();
+  void test_saveAll_loadAll_doNotCrash();
+  void test_overwrite_previouslySetKey();
+
+ private:
+  // Unique group names per test slot to avoid cross-contamination with
+  // the persistent QSettings store (which the singleton always uses).
+  QString uniqueGroup(const QString& suffix) const;
+};
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::initTestCase() {
+  // Touch singleton to ensure it exists.
+  SettingsManager::instance();
+}
+
+void TestSettingsManager::init() {
+  // Nothing to reset — tests use unique group names.
+}
+
+QString TestSettingsManager::uniqueGroup(const QString& suffix) const {
+  // Use the test object name + suffix so each test gets its own namespace.
+  return QStringLiteral("Test_%1_%2")
+      .arg(QTest::currentTestFunction())
+      .arg(suffix);
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_instance_returnsSameObject() {
+  SettingsManager* a = &SettingsManager::instance();
+  SettingsManager* b = &SettingsManager::instance();
+  QVERIFY2(a == b,
+           "instance() must return the same address on every call");
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_setValue_roundTrip_int() {
+  const QString group = uniqueGroup("int");
+  SettingsManager::instance().setValue(group, QStringLiteral("key"), 42);
+  QVariant result =
+      SettingsManager::instance().value(group, QStringLiteral("key"));
+  QCOMPARE(result.toInt(), 42);
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_setValue_roundTrip_double() {
+  const QString group = uniqueGroup("dbl");
+  SettingsManager::instance().setValue(group, QStringLiteral("key"), 3.14);
+  QVariant result =
+      SettingsManager::instance().value(group, QStringLiteral("key"));
+  QVERIFY2(qAbs(result.toDouble() - 3.14) < 1e-9,
+           "Double round-trip must preserve value");
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_setValue_roundTrip_string() {
+  const QString group = uniqueGroup("str");
+  const QString expected = QStringLiteral("Hello MWA");
+  SettingsManager::instance().setValue(group, QStringLiteral("key"), expected);
+  QVariant result =
+      SettingsManager::instance().value(group, QStringLiteral("key"));
+  QCOMPARE(result.toString(), expected);
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_setValue_roundTrip_bool() {
+  const QString group = uniqueGroup("bool");
+  SettingsManager::instance().setValue(group, QStringLiteral("key"), true);
+  QVariant result =
+      SettingsManager::instance().value(group, QStringLiteral("key"));
+  QVERIFY2(result.toBool() == true, "Bool round-trip must return true");
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_value_returnsDefault_whenKeyMissing() {
+  const QString group = uniqueGroup("nokey");
+  const QVariant def = QStringLiteral("default_val");
+  QVariant result =
+      SettingsManager::instance().value(group, QStringLiteral("absent"), def);
+  QCOMPARE(result.toString(), def.toString());
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_value_returnsStoredValue_notDefault() {
+  const QString group = uniqueGroup("pref");
+  SettingsManager::instance().setValue(group, QStringLiteral("k"),
+                                       QStringLiteral("stored"));
+  QVariant result = SettingsManager::instance().value(
+      group, QStringLiteral("k"), QStringLiteral("fallback"));
+  QCOMPARE(result.toString(), QStringLiteral("stored"));
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_settingChanged_emittedOnNewValue() {
+  const QString group = uniqueGroup("sig_new");
+  const QString key = QStringLiteral("k");
+  // Pre-seed a sentinel value distinct from what we will set, so that
+  // even if a previous test run persisted this key the spy will observe
+  // a genuine change.
+  SettingsManager::instance().setValue(group, key,
+                                       QStringLiteral("__sentinel__"));
+
+  QSignalSpy spy(&SettingsManager::instance(),
+                 &SettingsManager::settingChanged);
+  SettingsManager::instance().setValue(group, key, QStringLiteral("first"));
+  QVERIFY2(spy.count() >= 1,
+           "settingChanged must fire when value changes to a new value");
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_settingChanged_notEmitted_onSameValueSetAgain() {
+  const QString group = uniqueGroup("sig_same");
+  // Write the value once so it is persisted.
+  SettingsManager::instance().setValue(group, QStringLiteral("k"),
+                                       QStringLiteral("stable"));
+
+  QSignalSpy spy(&SettingsManager::instance(),
+                 &SettingsManager::settingChanged);
+  // Set the exact same value again.
+  SettingsManager::instance().setValue(group, QStringLiteral("k"),
+                                       QStringLiteral("stable"));
+  QCOMPARE(spy.count(), 0);
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_settingChanged_emittedOnValueChange() {
+  const QString group = uniqueGroup("sig_change");
+  SettingsManager::instance().setValue(group, QStringLiteral("k"),
+                                       QStringLiteral("old"));
+  QSignalSpy spy(&SettingsManager::instance(),
+                 &SettingsManager::settingChanged);
+  SettingsManager::instance().setValue(group, QStringLiteral("k"),
+                                       QStringLiteral("new"));
+  QCOMPARE(spy.count(), 1);
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_settingChanged_signalCarriesGroupKeyValue() {
+  const QString group = uniqueGroup("sig_payload");
+  const QString key = QStringLiteral("myKey");
+  const QVariant val = QStringLiteral("myValue");
+
+  // Ensure a prior different value so the signal fires.
+  SettingsManager::instance().setValue(group, key,
+                                       QStringLiteral("__initial__"));
+
+  QSignalSpy spy(&SettingsManager::instance(),
+                 &SettingsManager::settingChanged);
+  SettingsManager::instance().setValue(group, key, val);
+
+  QCOMPARE(spy.count(), 1);
+  const QList<QVariant>& args = spy.at(0);
+  QCOMPARE(args.at(0).toString(), group);
+  QCOMPARE(args.at(1).toString(), key);
+  QCOMPARE(args.at(2).toString(), val.toString());
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_differentGroups_isolateSettings() {
+  const QString group_a = uniqueGroup("grp_A");
+  const QString group_b = uniqueGroup("grp_B");
+  const QString key = QStringLiteral("shared_key");
+
+  SettingsManager::instance().setValue(group_a, key,
+                                       QStringLiteral("valueA"));
+  SettingsManager::instance().setValue(group_b, key,
+                                       QStringLiteral("valueB"));
+
+  QCOMPARE(
+      SettingsManager::instance().value(group_a, key).toString(),
+      QStringLiteral("valueA"));
+  QCOMPARE(
+      SettingsManager::instance().value(group_b, key).toString(),
+      QStringLiteral("valueB"));
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_emptyKey_doesNotCrash() {
+  const QString group = uniqueGroup("emptykey");
+  // Should not throw or crash — result is implementation-defined.
+  SettingsManager::instance().setValue(group, QString(), 99);
+  SettingsManager::instance().value(group, QString());
+  QVERIFY(true);  // Reaching here means no crash.
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_emptyGroup_doesNotCrash() {
+  // Should not throw or crash.
+  SettingsManager::instance().setValue(QString(),
+                                       QStringLiteral("k_empty_grp"), 1);
+  SettingsManager::instance().value(QString(),
+                                    QStringLiteral("k_empty_grp"));
+  QVERIFY(true);
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_saveAll_loadAll_doNotCrash() {
+  SettingsManager::instance().saveAll();
+  SettingsManager::instance().loadAll();
+  QVERIFY(true);
+}
+
+// ---------------------------------------------------------------------------
+void TestSettingsManager::test_overwrite_previouslySetKey() {
+  const QString group = uniqueGroup("overwrite");
+  const QString key = QStringLiteral("k");
+  SettingsManager::instance().setValue(group, key, 1);
+  SettingsManager::instance().setValue(group, key, 2);
+  QCOMPARE(SettingsManager::instance().value(group, key).toInt(), 2);
+}
+
+// ---------------------------------------------------------------------------
+QTEST_MAIN(TestSettingsManager)
+#include "test_settings_manager.moc"


### PR DESCRIPTION
## PR Handoff Summary for Owner

### What Changed
- **Logger** (`src/core/logger.h/.cpp`) — Thread-safe singleton wrapping Qt message handling. Emits `newLogEntry(LogEntry)` signal. Intercepts qDebug/qWarning/qCritical via `qInstallMessageHandler`.
- **SettingsManager** (`src/core/settings_manager.h/.cpp`) — Singleton wrapping QSettings with INI format. Groups by device ("LED", "Pump", etc.). Emits `settingChanged()` on value change.
- **DeviceInterface** (`src/hardware/device_interface.h`) — Pure abstract QObject base class for all hardware devices. Defines `DeviceState` and `DeviceType` enums (inside class for proper Q_ENUM registration). Declares `connectDevice()`, `disconnectDevice()`, `state()`, `isConnected()`, signals `stateChanged()` and `errorOccurred()`.
- **CMake integration** — `MwaCore` static library, `MwaHardware` interface library, linked to main executable.
- **Sprint plan** (`docs/tasks/sprints.md`) — Added full 6-sprint plan with dependency graphs.

### Requirement IDs Addressed
- GUI-REQ-009 (Logger)
- GUI-REQ-010 (Settings Manager)
- HW-REQ-001 (Device Interface)
- NFR-004 (Code quality/documentation)
- NFR-007 (Hardware abstraction)

### What to Test (Owner Manual Testing)
1. **Build**: `cmake -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build` — should complete with zero warnings
2. **Tests**: `cd build && ctest --output-on-failure` — all 4 tests must pass (46 test slots total)
3. **Logger**: Check `src/core/logger.h` — singleton pattern, thread-safe, signal emission
4. **SettingsManager**: Check `src/core/settings_manager.h` — QSettings INI format, group isolation
5. **DeviceInterface**: Check `src/hardware/device_interface.h` — pure virtual, enums inside class, Q_ENUM works

### What to Focus On
- **DeviceInterface enum placement** — Enums were moved inside the class body to fix Q_ENUM registration (TE-001 bug found and fixed during this round). Verify `Q_ENUM` tests pass.
- **Thread safety of Logger** — `QMutex` guards the `log()` method; signal is emitted under lock. Acceptable for now but may need optimization if high-frequency logging causes contention.
- **Architecture boundaries** — `mwa::core` has no GUI/hardware dependencies. `mwa::hardware` has no GUI dependencies. Clean separation verified.

### Doxygen Documentation Check
- All 5 new source files have `@file` headers
- All 3 classes have `@class` + `@brief` + detailed description
- All public methods have `@brief`, `@param`, `@return`
- Both enums have `@enum` + `@brief` with `///<` inline docs on every value
- `@note`, `@see` cross-references used throughout

### Test Results Summary
- Total tests: 4 executables (46 test slots)
- Passed: 4/4
- Failed: 0
- Platforms tested: macOS (ARM64)

### Known Issues / Limitations
- Logger emits signal under mutex lock — could cause re-entrancy issues if a slot tries to log. Acceptable for current scope; will optimize in Sprint 4 if needed.
- SettingsManager `loadAll()` currently just calls `sync()` — sufficient for INI format but may need enhancement for complex settings later.
- CI will test Windows compatibility on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)