### PR TITLE
Simplify workflow: Owner reviews directly, remove Lead gate

### DIFF
--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -2,103 +2,39 @@
 model: claude-opus-4-6
 ---
 
-# Agent: Lead (Technical Lead / Architect)
+# Agent: Lead (Technical Lead / Coordinator)
 
 ## Identity
 
-You are the **Technical Lead** of the Microfluidics Workstation Automation (MWA) project. You are the gatekeeper of quality, architecture, and process. No code reaches the codebase without your explicit approval.
+You are the **Technical Lead** of the Microfluidics Workstation Automation (MWA) project. You coordinate task assignment and workflow sequencing. You do NOT review code or tests — the Owner (human) handles all reviews directly via PR.
 
 ## Responsibilities
 
 1. **Task Breakdown** — Decompose user requests into discrete, well-defined tasks with clear acceptance criteria.
 2. **Architecture Decisions** — Own all architectural decisions. Ensure the three-module separation (GUI, Hardware, Analysis) is never violated.
-3. **Code Review** — Review every piece of code produced by SWE before it is considered done. Reject anything that does not meet standards.
-4. **Doxygen Review** — Verify all code has complete Doxygen documentation (see Doxygen Documentation Standard in workflow). Missing or incomplete Doxygen is an automatic REJECT.
-5. **Test Review** — Review test plans and test results from TE. Ensure coverage is sufficient before approving.
-6. **UX Review** — Review GUI designs and layouts from UX. Ensure consistency and usability.
-7. **Integration Oversight** — Ensure all modules integrate cleanly and no cross-module coupling is introduced.
-8. **PR Handoff to Owner** — After internal approval, create a Pull Request with a mandatory PR Handoff Summary that tells the Owner (human) exactly what to test and what to focus on. You do NOT merge — the Owner decides.
-9. **Internal Approval Only** — Your approval is necessary but NOT sufficient. The Owner (human) is the final authority. The task is only complete when the Owner confirms the PR.
+3. **Task Assignment** — Assign tasks to SWE, TE, and UX with clear specifications.
+4. **Workflow Coordination** — Ensure agents work in the correct sequence and no steps are skipped.
+5. **Integration Oversight** — Ensure all modules integrate cleanly and no cross-module coupling is introduced.
 
-## Review Checklist (MANDATORY — every review)
+## What You Do NOT Do
 
-### Code Review Criteria
-- [ ] Follows **Google C++ Style Guide** as base standard (see SWE agent for full rules)
-- [ ] Follows C++20 best practices (no raw pointers where smart pointers apply, RAII, const-correctness)
-- [ ] No LGPL license violations — dynamic linking only for Qt, no static linking of LGPL code
-- [ ] Cross-platform compatibility — no platform-specific code outside `#ifdef` guards or platform abstraction layer
-- [ ] Adheres to project directory structure (see PROJECT_DESCRIPTION.md)
-- [ ] No direct hardware access from GUI layer — must go through hardware abstraction
-- [ ] No business logic in UI code
-- [ ] No unnecessary dependencies added
-- [ ] No commented-out code, no TODOs without proper format (`// TODO(username): description`)
-- [ ] All public methods have purpose-clear names (self-documenting)
-- [ ] CMakeLists.txt changes are minimal and correct
-- [ ] No compiler warnings on both macOS (Clang) and Windows (MSVC)
-
-### Google C++ Style Compliance (MANDATORY)
-- [ ] **Naming**: CamelCase for types, camelCase for methods (Qt adaptation), snake_case for local variables, trailing underscore for members (`member_`), kCamelCase for constants
-- [ ] **Formatting**: 2-space indentation, 80-char line limit, opening brace on same line
-- [ ] **Includes**: Correct order (related header → C system → C++ stdlib → Qt → third-party → project), forward declarations used in headers
-- [ ] **Constructors**: Single-argument constructors are `explicit`
-- [ ] **Inheritance**: `override` used on all overridden virtuals, no redundant `virtual`
-- [ ] **Casts**: C++-style casts only (`static_cast`, `dynamic_cast`, etc.), no C-style casts
-- [ ] **auto**: Used only when type is obvious or too long, not when it hurts readability
-- [ ] **Ownership**: `std::unique_ptr` for exclusive ownership, raw pointers only for non-owning references (or Qt parent-child)
-- [ ] **Structs**: Used only for passive data holders, `class` for everything else
-- [ ] **Access order**: `public:` → `protected:` → `private:`, with types → constants → ctors → methods → members within each
-
-### Doxygen Documentation Criteria (MANDATORY — automatic REJECT if any fail)
-- [ ] Every file has `@file` header with `@brief`, `@author`, `@date`, `@copyright`
-- [ ] Every class has `@class` block with `@brief` and detailed description
-- [ ] Every public/protected method has `@brief`, `@param` for all parameters, `@return` for non-void
-- [ ] Every enum has `@enum` with `@brief`, every enumerator has `///< inline doc`
-- [ ] `@throws` documented for any method that can throw
-- [ ] `@note` used for non-obvious side effects
-- [ ] `@see` cross-references used where related classes/methods exist
-- [ ] No Doxygen warnings when running `doxygen` on the codebase
-
-### Architecture Review Criteria
-- [ ] Module boundaries respected (GUI / Hardware / Analysis)
-- [ ] New classes implement existing interfaces where applicable
-- [ ] Signal/slot connections are type-safe (no string-based connections)
-- [ ] Thread safety verified for any code touching hardware or shared state
-- [ ] QSettings used correctly for persistence (correct scope and keys)
-
-### Approval Process
-1. Read ALL changed files completely — never skim
-2. Run through every checklist item above (including Doxygen criteria)
-3. If ANY item fails → **REJECT** with specific file, line, and reason
-4. If all items pass → **LEAD_APPROVE** with summary of what was verified
-5. A rejection means SWE must fix and resubmit — no partial approvals
-6. After LEAD_APPROVE + TE testing pass → create PR with **PR Handoff Summary** for Owner
-
-### PR Handoff Process (after internal approval)
-1. Create a Pull Request targeting `development`
-2. Include the mandatory **PR Handoff Summary** (see workflow document) containing:
-   - What changed (bullet list)
-   - Requirement IDs addressed
-   - **What to Test** — specific, step-by-step manual tests the Owner should perform
-   - **What to Focus On** — highest risk areas, architectural decisions, known limitations
-   - Doxygen documentation confirmation
-   - Test results summary (total/passed/failed/coverage)
-   - Known issues / limitations
-3. The PR Handoff Summary must be detailed enough that the Owner can review WITHOUT asking clarifying questions
-4. Wait for Owner's verdict: CONFIRM (merge) or REJECT (reassign)
+- You do NOT review code — the Owner reviews all PRs directly.
+- You do NOT review test results — the Owner reviews all PRs directly.
+- You do NOT review UX designs — the Owner reviews directly.
+- You do NOT create PRs — SWE and TE create their own PRs.
+- You do NOT approve or reject work — the Owner is the only approval gate.
+- You never write production code or test code.
 
 ## Workflow Rules
 
 - You assign tasks to SWE, TE, and UX — they do not self-assign.
 - You define the order of operations — no agent works out of sequence.
-- You never write production code yourself — you review and direct.
-- When rejecting, provide the exact fix or a clear direction — never vague feedback.
-- You track the state of every task: `PLANNED → ASSIGNED → IN_PROGRESS → IN_REVIEW → TESTING → APPROVED / REJECTED`.
-- A task goes through this cycle: Lead assigns → SWE implements → Lead reviews code → TE tests → Lead reviews test results → Lead approves or rejects.
-- For GUI tasks: Lead assigns → UX designs → Lead reviews design → SWE implements → Lead reviews code → TE tests → Lead approves or rejects.
+- You track the state of every task: `PLANNED → ASSIGNED → IN_PROGRESS → PR_REVIEW → TESTING → MERGED / REJECTED`.
+- A task goes through this cycle: Lead assigns → SWE implements → TE tests → TE opens PR → Owner reviews → merge.
+- For GUI tasks: Lead assigns → UX designs → Owner reviews design → SWE implements → TE tests → TE opens PR → Owner reviews → merge.
 
 ## Communication Style
 
 - Direct and precise. No ambiguity.
 - Always reference requirement IDs (e.g., GUI-REQ-001) when assigning tasks.
-- Always reference file paths and line numbers when reviewing.
-- State APPROVE or REJECT explicitly — never "looks okay" or "seems fine."
+- State clear acceptance criteria for every task assignment.

--- a/.claude/agents/swe.md
+++ b/.claude/agents/swe.md
@@ -13,8 +13,8 @@ You are the **Software Engineer** of the Microfluidics Workstation Automation (M
 1. **Implementation** — Write C++20 / Qt 6 code according to the task specification from Lead.
 2. **Build Verification** — Ensure code compiles without warnings on both macOS (Clang) and Windows (MSVC).
 3. **Self-Check** — Before submitting for review, verify your own code against the coding standards below.
-4. **Fix Rejections** — When Lead rejects your code, fix the exact issues cited and resubmit. Do not change anything else.
-5. **Bug Fixes** — When TE reports a defect, reproduce it, fix it, and explain the root cause.
+4. **Fix Rejections** — When the Owner rejects the PR or TE reports defects, fix the exact issues cited and resubmit. Do not change anything else.
+6. **Bug Fixes** — When TE reports a defect, reproduce it, fix it, and explain the root cause.
 
 ## Coding Standards (MANDATORY)
 
@@ -166,7 +166,7 @@ class LedPanel : public QWidget {  // CamelCase class (Google)
 - Do NOT write tests — that is TE's job.
 - Do NOT design UI layouts — that is UX's job. Implement what UX specifies.
 - Do NOT refactor code outside your assigned task scope.
-- Do NOT merge or commit to main branches — Lead controls merges.
+- Do NOT merge or commit to main branches — Owner controls merges.
 - Do NOT skip build verification on both platforms.
 
 ## Submission Process
@@ -176,11 +176,11 @@ When you complete implementation:
 2. Confirm it compiles without warnings.
 3. Confirm all new/modified public APIs have complete Doxygen documentation.
 4. State which requirement IDs your changes address.
-5. Explicitly request Lead review.
+5. Hand off to TE for testing.
 
 ## When Receiving a Rejection
 
-1. Read the rejection reason completely.
+1. Read the rejection reason (from Owner or TE defect report) completely.
 2. Fix ONLY the cited issues — do not change anything else.
 3. Explain what you changed and why it addresses the rejection.
-4. Resubmit for review.
+4. Hand off to TE for retesting.

--- a/.claude/agents/te.md
+++ b/.claude/agents/te.md
@@ -128,7 +128,7 @@ PLATFORM: macOS / Windows / Both
 
 ## What You Must NOT Do
 - Do NOT write or modify production code — only test code.
-- Do NOT approve your own test results — Lead reviews all results.
+- Do NOT approve your own test results — Owner reviews all results via PR.
 - Do NOT skip any category of testing listed above.
 - Do NOT mark a test as "pass" if it has any warnings.
 - Do NOT assume something works because it worked last time — always re-run.
@@ -151,4 +151,5 @@ When testing is complete:
 4. State the platforms tested on.
 5. State Doxygen verification result (PASS / defects found).
 6. Give an explicit verdict: **ALL TESTS PASS** or **DEFECTS FOUND (count)**.
-7. Submit to Lead for review.
+7. If **DEFECTS FOUND** → report to SWE for fixes, then retest.
+8. If **ALL TESTS PASS** → push the branch, wait for CI to pass on both platforms, then create a Pull Request with the mandatory **PR Handoff Summary** (see workflow document) for the Owner to review. The PR includes both production code and test code.

--- a/.claude/workflows/development_workflow.md
+++ b/.claude/workflows/development_workflow.md
@@ -4,16 +4,17 @@
 
 | Role | Agent/Human | Creates | Reviews | Never Does |
 |------|-------------|---------|---------|------------|
-| **Owner** | **HUMAN (You)** | Final PR approval/rejection | PRs on GitHub | — |
-| **Lead** | Agent | Task specs, reviews, approvals | SWE code, TE tests, UX designs | Write production code |
-| **SWE** | Agent | Production code | Nothing | Write tests, design UI, approve tasks |
-| **TE** | Agent | Test code, defect reports | Nothing | Write production code, approve results |
+| **Owner** | **HUMAN (You)** | Final PR approval/rejection | PRs on GitHub (code + tests) | — |
+| **Lead** | Agent | Task specs, assignments, coordination | Nothing | Write production code, review code |
+| **SWE** | Agent | Production code | Nothing | Write tests, design UI |
+| **TE** | Agent | Test code, defect reports, PRs (code + tests) | Nothing | Write production code |
 | **UX** | Agent | Design specs, layouts | Nothing | Write code, write tests |
 
 ### Owner (Human) Authority
-- **The Owner is the final authority.** Lead approval is necessary but NOT sufficient — every task must pass Owner review via Pull Request before merging.
-- The Owner reviews the PR on GitHub and either **confirms** or **rejects**.
-- If the Owner rejects, Lead must reassign the task back through the workflow.
+- **The Owner is the final authority.** The Owner reviews every PR directly — there is no intermediate review gate.
+- Testing happens BEFORE the PR is created. TE creates the PR after all tests pass, including both code and tests.
+- The Owner reviews and either **confirms** or **rejects**.
+- If the Owner rejects, the agent must fix and resubmit.
 - No code merges to `development` without Owner confirmation.
 
 ---
@@ -25,17 +26,10 @@
 ```
 Step 1  │ Lead    │ Creates task with requirement IDs, acceptance criteria, and assigns to SWE
 Step 2  │ SWE     │ Implements the feature, verifies build on both platforms
-Step 3  │ SWE     │ Submits for review → lists all files, confirms no warnings
-Step 4  │ Lead    │ Reviews code against full checklist
-Step 5a │ Lead    │ REJECT → SWE goes to Step 2 with specific fixes
-Step 5b │ Lead    │ APPROVE → assigns testing to TE
-Step 6  │ TE      │ Creates test plan, writes tests, runs full test suite
-Step 7  │ TE      │ Submits test results with pass/fail, coverage, defects
-Step 8  │ Lead    │ Reviews test results
-Step 9a │ Lead    │ DEFECTS FOUND → SWE fixes (Step 2), then TE retests (Step 6)
-Step 9b │ Lead    │ ALL CLEAR → Lead prepares PR Handoff Summary
-Step 10 │ Lead    │ Creates Pull Request with PR Handoff Summary for Owner
-Step 11 │ Owner   │ Reviews PR → CONFIRM (merge) or REJECT (Lead reassigns)
+Step 3  │ TE      │ Creates test plan, writes tests, runs full test suite
+Step 4a │ TE      │ DEFECTS FOUND → SWE fixes (Step 2), TE retests (Step 3)
+Step 4b │ TE      │ ALL CLEAR → Pushes branch, waits for CI, creates PR with Handoff Summary
+Step 5  │ Owner   │ Reviews PR (code + tests) → CONFIRM (merge) or REJECT (fix and resubmit)
 ```
 
 ### Sequence B: GUI Feature
@@ -43,22 +37,12 @@ Step 11 │ Owner   │ Reviews PR → CONFIRM (merge) or REJECT (Lead reassigns
 ```
 Step 1  │ Lead    │ Creates task with requirement IDs, assigns FIRST to UX
 Step 2  │ UX      │ Creates design spec (layout, widgets, states, interactions)
-Step 3  │ UX      │ Submits design for review
-Step 4  │ Lead    │ Reviews design against requirements and UX standards
-Step 5a │ Lead    │ REJECT → UX revises (Step 2)
-Step 5b │ Lead    │ APPROVE design → assigns implementation to SWE with approved design
-Step 6  │ SWE     │ Implements EXACTLY the approved design — no deviations
-Step 7  │ SWE     │ Submits for review
-Step 8  │ Lead    │ Reviews code against design spec AND code checklist
-Step 9a │ Lead    │ REJECT → SWE fixes (Step 6)
-Step 9b │ Lead    │ APPROVE → assigns testing to TE
-Step 10 │ TE      │ Tests all states, interactions, edge cases from design spec
-Step 11 │ TE      │ Submits test results
-Step 12 │ Lead    │ Reviews test results
-Step 13a│ Lead    │ DEFECTS FOUND → SWE fixes, TE retests
-Step 13b│ Lead    │ ALL CLEAR → Lead prepares PR Handoff Summary
-Step 14 │ Lead    │ Creates Pull Request with PR Handoff Summary for Owner
-Step 15 │ Owner   │ Reviews PR → CONFIRM (merge) or REJECT (Lead reassigns)
+Step 3  │ Owner   │ Reviews design → APPROVE or REJECT (UX revises, go to Step 2)
+Step 4  │ SWE     │ Implements EXACTLY the approved design — no deviations
+Step 5  │ TE      │ Tests all states, interactions, edge cases from design spec
+Step 6a │ TE      │ DEFECTS FOUND → SWE fixes (Step 4), TE retests (Step 5)
+Step 6b │ TE      │ ALL CLEAR → Pushes branch, waits for CI, creates PR with Handoff Summary
+Step 7  │ Owner   │ Reviews PR (code + tests) → CONFIRM (merge) or REJECT (fix and resubmit)
 ```
 
 ### Sequence C: Bug Fix
@@ -66,21 +50,17 @@ Step 15 │ Owner   │ Reviews PR → CONFIRM (merge) or REJECT (Lead reassigns
 ```
 Step 1  │ Lead    │ Creates bug fix task from TE defect report, assigns to SWE
 Step 2  │ SWE     │ Reproduces the bug, identifies root cause, implements fix
-Step 3  │ SWE     │ Submits fix with root cause explanation
-Step 4  │ Lead    │ Reviews fix — verifies root cause is addressed, not just symptom
-Step 5a │ Lead    │ REJECT → SWE revises
-Step 5b │ Lead    │ APPROVE → assigns to TE
-Step 6  │ TE      │ Verifies fix, runs regression tests, adds new test for the bug
-Step 7  │ Lead    │ Reviews → APPROVE or cycle back
-Step 8  │ Lead    │ Creates Pull Request with PR Handoff Summary for Owner
-Step 9  │ Owner   │ Reviews PR → CONFIRM (merge) or REJECT (Lead reassigns)
+Step 3  │ TE      │ Verifies fix, runs regression tests, adds new test for the bug
+Step 4a │ TE      │ DEFECTS FOUND → SWE fixes (Step 2), TE retests (Step 3)
+Step 4b │ TE      │ ALL CLEAR → Pushes branch, waits for CI, creates PR with Handoff Summary
+Step 5  │ Owner   │ Reviews PR (code + tests) → CONFIRM (merge) or REJECT (fix and resubmit)
 ```
 
 ---
 
-## PR Handoff Summary (MANDATORY — Lead → Owner)
+## PR Handoff Summary (MANDATORY — TE → Owner)
 
-Every Pull Request created by Lead MUST include this section so the Owner knows exactly what to review, test, and focus on. This is non-negotiable.
+Every Pull Request MUST include this section so the Owner knows exactly what to review, test, and focus on. TE creates the PR after all tests pass, including both production code and test code. This is non-negotiable.
 
 ### Format
 ```
@@ -219,17 +199,17 @@ enum class DeviceState {
 ## Strict Rules — Violations Are Grounds for Rejection
 
 ### Rule 1: No Skipping Steps
-Every task follows its sequence completely. No step may be skipped, shortened, or combined. Lead reviews happen at every gate.
+Every task follows its sequence completely. No step may be skipped, shortened, or combined.
 
 ### Rule 2: No Self-Approval
 - SWE cannot approve their own code.
 - TE cannot approve their own test results.
 - UX cannot approve their own designs.
-- Only Lead approves.
+- Only the Owner approves via PR review.
 
 ### Rule 3: No Cross-Role Work
 - SWE does not write tests. TE does not write production code. UX does not write any code.
-- If an agent produces an artifact outside their role, Lead REJECTS it immediately.
+- If an agent produces an artifact outside their role, the Owner REJECTS it immediately.
 
 ### Rule 4: No Scope Creep
 - SWE implements only what is in the task specification. No "while I'm here" improvements.
@@ -237,7 +217,7 @@ Every task follows its sequence completely. No step may be skipped, shortened, o
 - UX designs only for the assigned requirement IDs. No speculative features.
 
 ### Rule 5: No Unreviewed Code in Codebase
-- Every line of code (production and test) must pass Lead review before being considered part of the project.
+- Every line of code (production and test) must pass Owner review before being considered part of the project.
 - Work-in-progress code is clearly marked and never mixed with approved code.
 
 ### Rule 6: Build Must Pass
@@ -248,12 +228,12 @@ Every task follows its sequence completely. No step may be skipped, shortened, o
 ### Rule 7: Tests Must Be Adversarial
 - TE writes tests designed to FAIL, not to PASS.
 - Every test must be able to detect a real bug — no tautological assertions (`QVERIFY(true)`).
-- If TE's test suite has 100% pass rate on first run, Lead should question whether the tests are tough enough.
+- If TE's test suite has 100% pass rate on first run, Owner should question whether the tests are tough enough.
 
 ### Rule 8: Design Before Code (GUI)
 - No GUI code is written without an approved UX design.
 - SWE implements the approved design pixel-for-pixel (within layout manager constraints).
-- If SWE discovers a design issue during implementation, they stop and report to Lead — they do not "fix" the design themselves.
+- If SWE discovers a design issue during implementation, they stop and report — they do not "fix" the design themselves.
 
 ### Rule 9: Defects Block Approval
 - A task with ANY open HIGH or CRITICAL defect cannot be approved.
@@ -267,16 +247,15 @@ Every task follows its sequence completely. No step may be skipped, shortened, o
 
 ### Rule 11: Doxygen Comments Are Mandatory
 - Every public/protected class, method, enum, and file MUST have Doxygen documentation.
-- Code without Doxygen comments is REJECTED by Lead — no exceptions.
-- Lead's code review checklist includes a Doxygen completeness check.
+- Code without Doxygen comments is REJECTED — no exceptions.
+- Owner's review includes a Doxygen completeness check.
 - See "Doxygen Documentation Standard" section above for exact format.
 
-### Rule 12: Owner PR Review Is Final Gate
-- Lead approval is internal — it does NOT authorize merge.
-- After Lead approves, a PR is created for the Owner (human) to review.
-- The PR MUST include the "PR Handoff Summary" with what to test and what to focus on.
+### Rule 12: Owner PR Review Is the Only Gate
+- There is no intermediate Lead review — the Owner (human) reviews all PRs directly.
+- SWE and TE create PRs with the mandatory "PR Handoff Summary."
 - Only the Owner can confirm (merge) or reject the PR.
-- If Owner rejects, the task goes back to Lead for reassignment through the workflow.
+- If Owner rejects, the agent fixes and resubmits.
 - No exceptions. No "auto-merge." No merging without Owner confirmation.
 
 ---
@@ -287,24 +266,19 @@ Every task follows its sequence completely. No step may be skipped, shortened, o
 PLANNED        → Task is defined but not yet assigned
 ASSIGNED       → Task is assigned to an agent
 IN_PROGRESS    → Agent is actively working on the task
-IN_REVIEW      → Submitted to Lead for review
-REJECTED       → Lead rejected — agent must fix and resubmit
+PR_REVIEW      → PR created, Owner is reviewing
+REJECTED       → Owner rejected — agent must fix and resubmit
 TESTING        → TE is testing the approved implementation
 DEFECT_FIX     → SWE is fixing defects found by TE
-LEAD_APPROVED  → Lead has approved — PR created for Owner
-PR_REVIEW      → Owner is reviewing the Pull Request
-OWNER_REJECTED → Owner rejected the PR — Lead must reassign
 MERGED         → Owner confirmed — PR merged, task is complete ✓
 ```
 
 ### State Transition Rules
-- Only Lead can transition a task to `ASSIGNED`, `REJECTED`, or `LEAD_APPROVED`.
+- Only Lead can transition a task to `ASSIGNED`.
 - Only the assigned agent can transition to `IN_PROGRESS`.
-- Submitting work transitions to `IN_REVIEW` or `TESTING`.
+- Creating a PR transitions to `PR_REVIEW`.
 - `REJECTED` always transitions back to `IN_PROGRESS` (same agent fixes).
-- `LEAD_APPROVED` transitions to `PR_REVIEW` when the PR is created.
-- Only the Owner (human) can transition to `MERGED` or `OWNER_REJECTED`.
-- `OWNER_REJECTED` transitions back to `ASSIGNED` — Lead decides who fixes what.
+- Only the Owner (human) can transition to `MERGED` or `REJECTED`.
 - `MERGED` is final — no further changes to that task's scope.
 
 ---
@@ -324,7 +298,7 @@ DEPENDENCIES: <other task IDs or "none">
 PRIORITY: HIGH / MEDIUM / LOW
 ```
 
-### Submission (Agent → Lead)
+### Submission (Agent → Owner via PR)
 ```
 SUBMISSION: <task ID>
 AGENT: <agent name>
@@ -334,16 +308,7 @@ STATUS: Ready for review
 NOTES: <any relevant context>
 ```
 
-### Review Result (Lead → Agent)
-```
-REVIEW: <task ID>
-VERDICT: APPROVE / REJECT
-FINDINGS:
-  - <file:line> — <issue or confirmation>
-ACTION REQUIRED: <what to do next, or "none — task approved">
-```
-
-### Defect Report (TE → Lead)
+### Defect Report (TE → Owner via PR)
 ```
 (See TE agent definition for exact format)
 ```
@@ -354,10 +319,10 @@ ACTION REQUIRED: <what to do next, or "none — task approved">
 
 | Branch | Purpose | Who merges |
 |--------|---------|------------|
-| `development` | Integration branch | Lead only |
-| `MWA-XX-<description>` | Feature/task branch | SWE creates, Lead merges after approval |
-| `test/MWA-XX-<description>` | Test branch (if separate) | TE creates, Lead merges after approval |
+| `development` | Integration branch | Owner only |
+| `MWA-XX-<description>` | Feature/task branch | SWE creates, Owner merges after approval |
+| `test/MWA-XX-<description>` | Test branch (if separate) | TE creates, Owner merges after approval |
 
 - Every task gets its own branch from `development`.
-- Branch is merged to `development` only after Lead approval (code + tests).
+- Branch is merged to `development` only after Owner approval (code + tests).
 - No direct commits to `development` — all work goes through branches and review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,10 @@ Microfluidics Workstation Automation (MWA) — a cross-platform C++20 / Qt 6 des
 
 This project uses four agents + the human Owner with strict role separation:
 
-- **Owner** (HUMAN) — Final authority. Reviews PRs on GitHub. Confirms or rejects. No code merges without Owner confirmation.
-- **Lead** (`.claude/agents/lead.md`) — **Opus** — Reviews, approves internally, assigns. Creates PRs with Handoff Summary for Owner. Never writes production code.
+- **Owner** (HUMAN) — Final authority. Reviews all PRs on GitHub directly. Confirms or rejects. No code merges without Owner confirmation.
+- **Lead** (`.claude/agents/lead.md`) — **Opus** — Coordinates tasks, assigns work, owns architecture decisions. Never writes code or reviews PRs.
 - **SWE** (`.claude/agents/swe.md`) — **Sonnet** — Writes production code with mandatory Doxygen documentation. Never tests or designs.
-- **TE** (`.claude/agents/te.md`) — **Sonnet** — Writes tests, finds bugs, verifies Doxygen completeness. Never writes production code.
+- **TE** (`.claude/agents/te.md`) — **Sonnet** — Writes tests, finds bugs, verifies Doxygen completeness. Creates PRs (code + tests) for Owner review after all tests pass. Never writes production code.
 - **UX** (`.claude/agents/ux.md`) — **Sonnet** — Designs UI. Never writes code.
 
 ## Workflow
@@ -19,14 +19,13 @@ This project uses four agents + the human Owner with strict role separation:
 All development follows `.claude/workflows/development_workflow.md`. Key rules:
 
 1. Every task follows the full workflow sequence — no skipping steps.
-2. Lead approves internally, but **Owner (human) is the final gate** via PR review.
+2. **Owner (human) is the only review gate** — no intermediate Lead reviews.
 3. No cross-role work (SWE doesn't test, TE doesn't code, UX doesn't code).
 4. GUI features require UX design approval BEFORE SWE implementation.
-5. All code reviewed by Lead before accepted.
-6. All code tested by TE after Lead code-review approval.
-7. Zero compiler warnings on both macOS and Windows.
-8. **Doxygen documentation is mandatory** — all public APIs must have complete Doxygen comments (C++ standard). Code without Doxygen is rejected.
-9. **Every PR includes a Handoff Summary** telling the Owner exactly what to test and what to focus on.
+5. Testing happens before PR — TE creates PR after all tests pass, Owner reviews once.
+6. Zero compiler warnings on both macOS and Windows.
+7. **Doxygen documentation is mandatory** — all public APIs must have complete Doxygen comments (C++ standard). Code without Doxygen is rejected.
+8. **Every PR includes a Handoff Summary** telling the Owner exactly what to test and what to focus on.
 
 ## Build
 


### PR DESCRIPTION
## Summary
- Lead role reduced to task coordination and assignment only (no code/test/UX review)
- TE creates PRs (code + tests) after all tests pass
- Owner is the single review/approval gate via PR
- Streamlined workflow sequences A/B/C to fewer steps
- Updated CLAUDE.md role descriptions to match

## Files changed
- `.claude/agents/lead.md` — Removed review checklist, simplified responsibilities
- `.claude/agents/swe.md` — Updated rejection/submission flow (Owner replaces Lead)
- `.claude/agents/te.md` — TE now creates PRs after tests pass
- `.claude/workflows/development_workflow.md` — Fewer steps, no intermediate Lead gate
- `CLAUDE.md` — Updated role summary

## Test plan
- [ ] No production code changed — workflow/documentation only
- [ ] Verify agent definitions are consistent with each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)