### PR TITLE
MWA-05: Serial utilities + LED & Stage hardware drivers

### DIFF
--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -12,8 +12,8 @@ You are the **Technical Lead** of the Microfluidics Workstation Automation (MWA)
 
 1. **Task Breakdown** — Decompose user requests into discrete, well-defined tasks with clear acceptance criteria.
 2. **Architecture Decisions** — Own all architectural decisions. Ensure the three-module separation (GUI, Hardware, Analysis) is never violated.
-3. **Task Assignment** — Assign tasks to SWE, TE, and UX with clear specifications.
-4. **Workflow Coordination** — Ensure agents work in the correct sequence and no steps are skipped.
+3. **Task Assignment & Start** — Assign tasks to SWE, TE, and UX with clear specifications, then **immediately begin execution** — do not wait for the Owner to say "go on" or confirm between steps.
+4. **Workflow Coordination** — Drive the full chain Lead → SWE → TE → PR without pausing for intermediate approval. For standard features, the only pause is at the PR. GUI features pause twice: once for design review (before SWE starts) and once for PR review.
 5. **Integration Oversight** — Ensure all modules integrate cleanly and no cross-module coupling is introduced.
 
 ## What You Do NOT Do
@@ -30,8 +30,8 @@ You are the **Technical Lead** of the Microfluidics Workstation Automation (MWA)
 - You assign tasks to SWE, TE, and UX — they do not self-assign.
 - You define the order of operations — no agent works out of sequence.
 - You track the state of every task: `PLANNED → ASSIGNED → IN_PROGRESS → PR_REVIEW → TESTING → MERGED / REJECTED`.
-- A task goes through this cycle: Lead assigns → SWE implements → TE tests → TE opens PR → Owner reviews → merge.
-- For GUI tasks: Lead assigns → UX designs → Owner reviews design → SWE implements → TE tests → TE opens PR → Owner reviews → merge.
+- A task goes through this cycle: Lead assigns and **starts immediately** → SWE implements → TE tests and opens PR → Owner reviews → merge. No "go on" prompts between these steps.
+- For GUI tasks: Lead assigns → UX designs → **Owner reviews design** (first pause — before SWE starts) → SWE implements → TE tests and opens PR → **Owner reviews PR** (second pause) → merge.
 
 ## Communication Style
 

--- a/.claude/workflows/development_workflow.md
+++ b/.claude/workflows/development_workflow.md
@@ -24,26 +24,30 @@
 ### Sequence A: Standard Feature (non-GUI)
 
 ```
-Step 1  │ Lead    │ Creates task with requirement IDs, acceptance criteria, and assigns to SWE
-Step 2  │ SWE     │ Implements the feature, verifies build on both platforms
-Step 3  │ TE      │ Creates test plan, writes tests, runs full test suite
+Step 1  │ Lead    │ Creates task with requirement IDs, acceptance criteria — then IMMEDIATELY starts Step 2 (no pause)
+Step 2  │ SWE     │ Implements the feature, verifies build on both platforms — then IMMEDIATELY starts Step 3 (no pause)
+Step 3  │ TE      │ Writes unit tests, runs full test suite
 Step 4a │ TE      │ DEFECTS FOUND → SWE fixes (Step 2), TE retests (Step 3)
 Step 4b │ TE      │ ALL CLEAR → Pushes branch, waits for CI, creates PR with Handoff Summary
 Step 5  │ Owner   │ Reviews PR (code + tests) → CONFIRM (merge) or REJECT (fix and resubmit)
 ```
 
+> **The only place the workflow pauses and waits for Owner input is Step 5 (PR review).**
+
 ### Sequence B: GUI Feature
 
 ```
-Step 1  │ Lead    │ Creates task with requirement IDs, assigns FIRST to UX
+Step 1  │ Lead    │ Creates task with requirement IDs — immediately starts UX design (no pause)
 Step 2  │ UX      │ Creates design spec (layout, widgets, states, interactions)
-Step 3  │ Owner   │ Reviews design → APPROVE or REJECT (UX revises, go to Step 2)
-Step 4  │ SWE     │ Implements EXACTLY the approved design — no deviations
-Step 5  │ TE      │ Tests all states, interactions, edge cases from design spec
+Step 3  │ Owner   │ *** PAUSE — reviews design → APPROVE (continue to Step 4) or REJECT (UX revises, back to Step 2)
+Step 4  │ SWE     │ Implements EXACTLY the approved design — immediately hands off to TE (no pause)
+Step 5  │ TE      │ Writes tests for all states, interactions, edge cases from design spec
 Step 6a │ TE      │ DEFECTS FOUND → SWE fixes (Step 4), TE retests (Step 5)
 Step 6b │ TE      │ ALL CLEAR → Pushes branch, waits for CI, creates PR with Handoff Summary
-Step 7  │ Owner   │ Reviews PR (code + tests) → CONFIRM (merge) or REJECT (fix and resubmit)
+Step 7  │ Owner   │ *** PAUSE — reviews PR (code + tests) → CONFIRM (merge) or REJECT (fix and resubmit)
 ```
+
+> **GUI workflow pauses exactly twice: design review (Step 3) and PR review (Step 7).**
 
 ### Sequence C: Bug Fix
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,11 @@ This project uses four agents + the human Owner with strict role separation:
 
 All development follows `.claude/workflows/development_workflow.md`. Key rules:
 
-1. Every task follows the full workflow sequence — no skipping steps.
-2. **Owner (human) is the only review gate** — no intermediate Lead reviews.
+1. **Lead assigns, describes, and immediately starts tasks** — the full chain Lead → SWE → TE → PR runs without pausing for "go on" at each step.
+2. **Owner (human) is the only review gate** — reviews the final PR and merges if everything is okay. No intermediate approvals except UX design sign-off for GUI features.
 3. No cross-role work (SWE doesn't test, TE doesn't code, UX doesn't code).
-4. GUI features require UX design approval BEFORE SWE implementation.
-5. Testing happens before PR — TE creates PR after all tests pass, Owner reviews once.
+4. GUI features require UX design approval BEFORE SWE implementation (only intermediate pause — before coding starts).
+5. **TE writes unit tests, runs them, and opens the PR** — testing and PR creation are one continuous step after SWE finishes.
 6. Zero compiler warnings on both macOS and Windows.
 7. **Doxygen documentation is mandatory** — all public APIs must have complete Doxygen comments (C++ standard). Code without Doxygen is rejected.
 8. **Every PR includes a Handoff Summary** telling the Owner exactly what to test and what to focus on.

--- a/docs/gui_design_spec.md
+++ b/docs/gui_design_spec.md
@@ -1,0 +1,611 @@
+# MWA — Unified GUI Panel Design Specification
+
+## Design Philosophy
+
+**One pattern, six devices.** Every panel follows the exact same visual and structural template. A user who learns the LED panel instantly understands the Camera panel. Differences are only in device-specific controls — the shell, layout, and interaction patterns are identical.
+
+---
+
+## Universal Panel Template
+
+Every device panel is a `QDockWidget` containing a single `QWidget` with this vertical layout:
+
+```
+┌─────────────────────────────────────────────────┐
+│ ■ LED Light Source                    [×]        │  ← Dock title bar (Qt default)
+├─────────────────────────────────────────────────┤
+│                                                 │
+│  ┌─ Connection ────────────────────────────┐    │  SECTION 1: Connection
+│  │  Port: [COM3          ▾]  Baud: [115200]│    │  (always the same for serial devices)
+│  │  [● Connected]          [ Disconnect ]  │    │
+│  └─────────────────────────────────────────┘    │
+│                                                 │
+│  ┌─ Controls ──────────────────────────────┐    │  SECTION 2: Controls
+│  │                                         │    │  (device-specific inputs)
+│  │  < device-specific control widgets >    │    │
+│  │                                         │    │
+│  └─────────────────────────────────────────┘    │
+│                                                 │
+│  ┌─ Status ────────────────────────────────┐    │  SECTION 3: Status
+│  │                                         │    │  (device-specific read-only feedback)
+│  │  < device-specific status widgets >     │    │
+│  │                                         │    │
+│  └─────────────────────────────────────────┘    │
+│                                                 │
+└─────────────────────────────────────────────────┘
+```
+
+### Three Sections — Always In This Order
+
+| # | Section | Purpose | Same Across All Panels? |
+|---|---------|---------|------------------------|
+| 1 | **Connection** | Port selection, connect/disconnect, status dot | YES — identical layout |
+| 2 | **Controls** | User inputs (sliders, spinboxes, buttons) | NO — device-specific |
+| 3 | **Status** | Read-only feedback from device | NO — device-specific |
+
+Each section is a `QGroupBox` with a title. The groupbox titles are always: **"Connection"**, **"Controls"**, **"Status"**.
+
+---
+
+## Section 1: Connection (Identical for All Panels)
+
+```
+┌─ Connection ───────────────────────────────────────────┐
+│                                                        │
+│  Port:  [/dev/cu.usbserial-1420 ▾]   Baud: [115200 ▾] │
+│                                                        │
+│  ● Connected                          [ Disconnect ]   │
+│                                                        │
+└────────────────────────────────────────────────────────┘
+```
+
+### Widgets
+
+| Widget | Type | Behavior |
+|--------|------|----------|
+| Port combo | `QComboBox` | Populated from `QSerialPortInfo::availablePorts()`. Refresh button (⟳) next to it. Disabled while connected. |
+| Baud combo | `QComboBox` | Values: 9600, 19200, 38400, 57600, 115200. Disabled while connected. |
+| Status dot + label | `QLabel` | ● Green "Connected" / ● Yellow "Connecting..." / ● Red "Error: ..." / ● Gray "Disconnected" |
+| Connect/Disconnect button | `QPushButton` | Text toggles: "Connect" (when disconnected) / "Disconnect" (when connected). Disabled during connecting. |
+
+### Status Dot Colors (consistent everywhere)
+
+| State | Dot | Label |
+|-------|-----|-------|
+| `kDisconnected` | ⚫ Gray (#888888) | "Disconnected" |
+| `kConnecting` | 🟡 Yellow (#F5A623) | "Connecting..." |
+| `kConnected` | 🟢 Green (#4CAF50) | "Connected" |
+| `kError` | 🔴 Red (#F44336) | "Error: {message}" |
+
+### Camera Exception
+
+Camera uses Pylon SDK (not serial), so its Connection section is slightly different:
+
+```
+┌─ Connection ───────────────────────────────────────────┐
+│                                                        │
+│  Camera:  [Basler acA2440-35um (22012345) ▾]           │
+│                                                        │
+│  ● Connected                          [ Disconnect ]   │
+│                                                        │
+└────────────────────────────────────────────────────────┘
+```
+
+The port/baud combos are replaced by a single camera selector combo populated from device enumeration. Same status dot, same connect/disconnect button.
+
+---
+
+## Section 2: Controls (Device-Specific)
+
+All controls use the same widget patterns:
+
+### Widget Pattern Library
+
+**A. Labeled Spinbox** — for numeric inputs
+
+```
+  Flow Rate:  [ 5.000   ↕ ] µL/min
+```
+
+- `QLabel` (left-aligned) + `QDoubleSpinBox` + unit suffix
+- Label width fixed at 100px for alignment
+- Spinbox stretches to fill
+
+**B. Labeled Slider + Spinbox** — for range controls
+
+```
+  Intensity:  ──────●────────  [ 75.0  ↕ ] %
+```
+
+- `QLabel` + `QSlider` (horizontal) + `QDoubleSpinBox` + unit suffix
+- Slider and spinbox bidirectionally synced
+- Used for: LED intensity
+
+**C. Combo Selector** — for enum choices
+
+```
+  Waveform:   [ Sine         ▾ ]
+```
+
+- `QLabel` + `QComboBox`
+- Used for: waveform, frequency unit
+
+**D. Action Button** — for triggering operations
+
+```
+  [ ▶ Start Infusion ]    [ ⏹ Stop ]
+```
+
+- `QPushButton` with text
+- States: enabled/disabled based on device state
+- Danger buttons (Stop, Emergency Stop): red background `#F44336`, white text
+
+**E. Toggle Button** — for on/off states
+
+```
+  [ ◉ Output ON  ]     ← green background when active
+  [ ○ Output OFF ]     ← default background when inactive
+```
+
+- `QPushButton` (checkable)
+- Checked = active state (green background `#4CAF50`, white text)
+- Unchecked = inactive state (default styling)
+- Used for: LED power, SigGen output, Camera continuous capture
+
+**F. Coordinate Group** — for X/Y/Z inputs (Stage only)
+
+```
+  X: [ 10.000 ↕ ] mm    Y: [ 5.000 ↕ ] mm    Z: [ 1.000 ↕ ] mm
+```
+
+- Three `QDoubleSpinBox` in a horizontal row with axis labels
+- Used for: Stage target position
+
+**G. Jog Pad** — for directional movement (Stage only)
+
+```
+          [ +Y ]
+  [ -X ]  [HOME]  [ +X ]
+          [ -Y ]
+
+  [ +Z ]  [STOP]  [ -Z ]
+
+  Step: [ 0.100 ↕ ] mm
+```
+
+- Grid of `QPushButton` (3×2 for XY, 1×2 for Z)
+- HOME button: calls `home()`
+- STOP button: red, always enabled, calls `stopMotion()`
+- Step spinbox: jog increment
+
+---
+
+## Section 3: Status (Device-Specific)
+
+All status displays use the same widget patterns:
+
+### Status Widget Patterns
+
+**A. Key-Value Row** — for single readings
+
+```
+  Current Intensity:    75.0 %
+  Power State:          ON
+```
+
+- `QLabel` (key, bold, fixed width) + `QLabel` (value, right-aligned or left-aligned)
+- Value updates via signal connection
+
+**B. Position Display** — for coordinates (Stage)
+
+```
+  Position:   X: 10.000 mm    Y: 5.000 mm    Z: 1.000 mm
+```
+
+- Three `QLabel` values in a horizontal row
+- Updated from `positionChanged(x, y, z)`
+
+**C. Progress Bar** — for ongoing operations
+
+```
+  Dispensing:  [████████░░░░░░░░░░░░]  50 / 100 µL
+```
+
+- `QProgressBar` + `QLabel` showing current/target
+- Used for: Pump dispensing, Camera batch capture
+
+**D. Chart View** — for data plots (VNA only)
+
+```
+  ┌──────────────────────────────────────┐
+  │ S21 Magnitude (dB)                   │
+  │                                      │
+  │   -20 ─         ╱╲                   │
+  │   -30 ─    ╱──╱    ╲──╲             │
+  │   -40 ─ ╱╱              ╲╲──        │
+  │   -50 ─╱                    ╲       │
+  │        ├────┬────┬────┬────┤        │
+  │       1.0  2.0  3.0  4.0  5.0 GHz  │
+  └──────────────────────────────────────┘
+```
+
+- `QChartView` with `QLineSeries`
+- X axis: frequency (auto-scaled with SI prefix)
+- Y axis: magnitude in dB
+- Updated after `measurementComplete()`
+
+**E. Image Preview** — for camera frames
+
+```
+  ┌──────────────────────────────────────┐
+  │                                      │
+  │            (live image)              │
+  │                                      │
+  │                                      │
+  └──────────────────────────────────────┘
+```
+
+- `QLabel` displaying scaled `QPixmap`
+- Aspect ratio preserved (`Qt::KeepAspectRatio`)
+- Black background
+- Updated from `frameReady(QImage)`
+
+---
+
+## Per-Panel Layouts
+
+### Panel 1: LED Light Source
+
+```
+┌─ Connection ───────────────────────────────────────┐
+│  Port: [▾]  Baud: [115200 ▾]                       │
+│  ● Connected                      [ Disconnect ]   │
+└────────────────────────────────────────────────────┘
+
+┌─ Controls ─────────────────────────────────────────┐
+│                                                    │
+│  Power:    [ ◉ ON  ]                               │  ← Toggle Button (E)
+│                                                    │
+│  Intensity: ──────●────────  [ 75.0  ↕ ] %         │  ← Slider+Spinbox (B)
+│                                                    │
+└────────────────────────────────────────────────────┘
+
+┌─ Status ───────────────────────────────────────────┐
+│  Current Intensity:    75.0 %                      │  ← Key-Value (A)
+│  Power State:          ON                          │  ← Key-Value (A)
+└────────────────────────────────────────────────────┘
+```
+
+### Panel 2: Syringe Pump
+
+```
+┌─ Connection ───────────────────────────────────────┐
+│  Port: [▾]  Baud: [115200 ▾]                       │
+│  ● Connected                      [ Disconnect ]   │
+└────────────────────────────────────────────────────┘
+
+┌─ Controls ─────────────────────────────────────────┐
+│                                                    │
+│  Flow Rate:      [ 5.000    ↕ ] µL/min             │  ← Labeled Spinbox (A)
+│  Target Volume:  [ 100.000  ↕ ] µL                 │  ← Labeled Spinbox (A)
+│                                                    │
+│  [ ▶ Start ]    [ ⏹ Stop ]    [ ↻ Refill ]        │  ← Action Buttons (D)
+│                                                    │
+└────────────────────────────────────────────────────┘
+
+┌─ Status ───────────────────────────────────────────┐
+│  Flow Rate:    5.000 µL/min                        │  ← Key-Value (A)
+│  Dispensed:    [████████░░░░░░]  50.0 / 100.0 µL   │  ← Progress Bar (C)
+│  State:        Infusing                            │  ← Key-Value (A)
+└────────────────────────────────────────────────────┘
+```
+
+### Panel 3: Signal Generator
+
+```
+┌─ Connection ───────────────────────────────────────┐
+│  Port: [▾]  Baud: [115200 ▾]                       │
+│  ● Connected                      [ Disconnect ]   │
+└────────────────────────────────────────────────────┘
+
+┌─ Controls ─────────────────────────────────────────┐
+│                                                    │
+│  Frequency:  [ 1.000    ↕ ] [MHz ▾]               │  ← Spinbox + Unit Combo
+│  Amplitude:  [ 2.500    ↕ ] Vpp                   │  ← Labeled Spinbox (A)
+│  Waveform:   [ Sine         ▾ ]                   │  ← Combo Selector (C)
+│                                                    │
+│  Output:     [ ◉ ON  ]                            │  ← Toggle Button (E)
+│                                                    │
+│  ── Sweep ──                                       │
+│  Start:  [ 0.500 ↕ ] MHz   Stop: [ 2.000 ↕ ] MHz │  ← Labeled Spinbox (A)
+│  Step:   [ 0.010 ↕ ] MHz                          │  ← Labeled Spinbox (A)
+│  [ Apply Sweep ]                                   │  ← Action Button (D)
+│                                                    │
+└────────────────────────────────────────────────────┘
+
+┌─ Status ───────────────────────────────────────────┐
+│  Frequency:    1.000 MHz                           │  ← Key-Value (A)
+│  Amplitude:    2.500 Vpp                           │  ← Key-Value (A)
+│  Waveform:     Sine                                │  ← Key-Value (A)
+│  Output:       ON                                  │  ← Key-Value (A)
+└────────────────────────────────────────────────────┘
+```
+
+### Panel 4: Network Analyzer (VNA)
+
+```
+┌─ Connection ───────────────────────────────────────┐
+│  Port: [▾]  Baud: [115200 ▾]                       │
+│  ● Connected                      [ Disconnect ]   │
+└────────────────────────────────────────────────────┘
+
+┌─ Controls ─────────────────────────────────────────┐
+│                                                    │
+│  Start Freq: [ 1.000  ↕ ] [GHz ▾]                 │  ← Spinbox + Unit Combo
+│  Stop Freq:  [ 5.000  ↕ ] [GHz ▾]                 │  ← Spinbox + Unit Combo
+│  Points:     [ 201    ↕ ]                          │  ← Labeled Spinbox (A)
+│                                                    │
+│  [ ▶ Measure ]                                     │  ← Action Button (D)
+│                                                    │
+└────────────────────────────────────────────────────┘
+
+┌─ Status ───────────────────────────────────────────┐
+│  State:   Ready                                    │  ← Key-Value (A)
+│                                                    │
+│  ┌──────────────────────────────────────────┐      │
+│  │ S21 Magnitude (dB) vs Frequency          │      │  ← Chart View (D)
+│  │                                          │      │
+│  │   (chart renders here after measurement) │      │
+│  │                                          │      │
+│  └──────────────────────────────────────────┘      │
+│                                                    │
+└────────────────────────────────────────────────────┘
+```
+
+### Panel 5: Camera
+
+```
+┌─ Connection ───────────────────────────────────────┐
+│  Camera: [Basler acA2440-35um (22012345) ▾]        │
+│  ● Connected                      [ Disconnect ]   │
+└────────────────────────────────────────────────────┘
+
+┌─ Controls ─────────────────────────────────────────┐
+│                                                    │
+│  Exposure:  [ 25.000  ↕ ] ms                       │  ← Labeled Spinbox (A)
+│  Gain:      [ 6.000   ↕ ] dB                       │  ← Labeled Spinbox (A)
+│                                                    │
+│  ── ROI ──                                         │
+│  X: [ 0  ↕ ]  Y: [ 0  ↕ ]  W: [ 640 ↕ ]  H: [ 480 ↕ ]  ← Coordinate Group (F)
+│                                                    │
+│  ── Capture ──                                     │
+│  [ Grab Single ]  [ ◉ Continuous ]                 │  ← Action (D) + Toggle (E)
+│                                                    │
+│  Batch:  Count: [ 10 ↕ ]  Interval: [ 500 ↕ ] ms  │  ← Labeled Spinbox (A)
+│  [ ▶ Start Batch ]                                 │  ← Action Button (D)
+│                                                    │
+└────────────────────────────────────────────────────┘
+
+┌─ Status ───────────────────────────────────────────┐
+│  ┌──────────────────────────────────────────┐      │
+│  │                                          │      │
+│  │           (live image preview)           │      │  ← Image Preview (E)
+│  │                                          │      │
+│  └──────────────────────────────────────────┘      │
+│  Batch:  [████████░░░░░░]  5 / 10 frames           │  ← Progress Bar (C)
+│  Exposure:  25.000 ms    Gain: 6.0 dB              │  ← Key-Value (A)
+└────────────────────────────────────────────────────┘
+```
+
+### Panel 6: XYZ Stage
+
+```
+┌─ Connection ───────────────────────────────────────┐
+│  Port: [▾]  Baud: [115200 ▾]                       │
+│  ● Connected                      [ Disconnect ]   │
+└────────────────────────────────────────────────────┘
+
+┌─ Controls ─────────────────────────────────────────┐
+│                                                    │
+│  ── Move To ──                                     │
+│  X: [ 10.000 ↕ ] mm  Y: [ 5.000 ↕ ] mm  Z: [ 1.000 ↕ ] mm  ← Coord Group (F)
+│  [ ▶ Go ]                                          │  ← Action Button (D)
+│                                                    │
+│  ── Jog ──                                         │
+│           [ +Y ]                                   │
+│   [ -X ]  [HOME]  [ +X ]                          │  ← Jog Pad (G)
+│           [ -Y ]                                   │
+│                                                    │
+│   [ +Z ]          [ -Z ]                           │
+│                                                    │
+│  Step: [ 0.100 ↕ ] mm                              │  ← Labeled Spinbox (A)
+│  Speed: [ 1.000 ↕ ] mm/s                           │  ← Labeled Spinbox (A)
+│                                                    │
+│  [ ⏹ STOP ]                                       │  ← Danger Button (D, red)
+│                                                    │
+└────────────────────────────────────────────────────┘
+
+┌─ Status ───────────────────────────────────────────┐
+│  Position:  X: 10.000 mm  Y: 5.000 mm  Z: 1.000 mm│  ← Position Display (B)
+│  Speed:     1.000 mm/s                             │  ← Key-Value (A)
+│  Motion:    Idle                                   │  ← Key-Value (A)
+└────────────────────────────────────────────────────┘
+```
+
+---
+
+## Main Window Layout
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  File   View   Devices   Help                                       │  ← Menu Bar
+├─────────────────────────────────────────────────────────────────────┤
+│  [Connect All]  [Disconnect All]  │  separator  │                   │  ← Toolbar
+├──────────────────────┬──────────────────────────────────────────────┤
+│                      │                                              │
+│   Device Panels      │           Central Workspace                  │
+│   (Left Dock Area)   │                                              │
+│                      │   ┌─ Status Dashboard ──────────────────┐    │
+│  ┌─ LED ──────────┐  │   │  Device      Type     Status        │    │
+│  │ (collapsed or  │  │   │  LED         Serial   ● Connected   │    │
+│  │  expanded)     │  │   │  Pump        Serial   ● Connected   │    │
+│  └────────────────┘  │   │  SigGen      Serial   ○ Disconnected│    │
+│                      │   │  VNA         Serial   ○ Disconnected│    │
+│  ┌─ Pump ─────────┐  │   │  Camera      USB3     ● Connected   │    │
+│  │                │  │   │  Stage       Serial   ● Connected   │    │
+│  └────────────────┘  │   │                                     │    │
+│                      │   │  [Connect All]    [Disconnect All]  │    │
+│  ┌─ SigGen ───────┐  │   └─────────────────────────────────────┘    │
+│  │                │  │                                              │
+│  └────────────────┘  │   ┌─ Camera Preview ────────────────────┐    │
+│                      │   │                                     │    │
+│  ┌─ VNA ──────────┐  │   │         (live camera image)         │    │
+│  │                │  │   │                                     │    │
+│  └────────────────┘  │   └─────────────────────────────────────┘    │
+│                      │                                              │
+│  ┌─ Camera ───────┐  │   ┌─ VNA Chart ────────────────────────┐    │
+│  │                │  │   │   (S-parameter plot)               │    │
+│  └────────────────┘  │   └─────────────────────────────────────┘    │
+│                      │                                              │
+│  ┌─ Stage ────────┐  │                                              │
+│  │                │  │                                              │
+│  └────────────────┘  │                                              │
+│                      │                                              │
+├──────────────────────┴──────────────────────────────────────────────┤
+│                                                                     │
+│  ┌─ Log ───────────────────────────────────────────────────────┐    │
+│  │  Severity: [All ▾]  Source: [All ▾]  [Clear]  [Export]      │    │  ← Bottom Dock
+│  │  ☐ Auto-scroll                                              │    │
+│  │                                                             │    │
+│  │  12:34:56.789  INFO     LED      Connected on /dev/cu.usb.. │    │
+│  │  12:34:57.001  INFO     Pump     Connected on COM3          │    │
+│  │  12:35:01.234  WARNING  Camera   Grab timeout, retrying     │    │
+│  │  12:35:02.567  ERROR    Stage    Axis X limit reached       │    │
+│  └─────────────────────────────────────────────────────────────┘    │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Dock Layout Rules
+
+| Dock Area | Panels | Default State |
+|-----------|--------|---------------|
+| Left | LED, Pump, SigGen, VNA, Camera, Stage (stacked/tabbed) | All visible, scrollable |
+| Center | Status Dashboard, Camera Preview, VNA Chart | Tabbed or stacked |
+| Bottom | Log Panel | Visible, height ~150px |
+
+### Menu Structure
+
+| Menu | Items |
+|------|-------|
+| **File** | Settings..., Separator, Exit |
+| **View** | Toggle LED Panel, Toggle Pump Panel, Toggle SigGen Panel, Toggle VNA Panel, Toggle Camera Panel, Toggle Stage Panel, Separator, Toggle Log Panel, Toggle Status Dashboard |
+| **Devices** | Connect All, Disconnect All, Separator, Refresh Ports |
+| **Help** | About MWA, About Qt |
+
+---
+
+## Styling Constants
+
+All panels use these shared constants (defined in a single header or QSS):
+
+```
+// Colors
+kColorConnected    = "#4CAF50"   // Green
+kColorConnecting   = "#F5A623"   // Yellow/Amber
+kColorError        = "#F44336"   // Red
+kColorDisconnected = "#888888"   // Gray
+kColorDangerButton = "#F44336"   // Red (Stop buttons)
+kColorActiveToggle = "#4CAF50"   // Green (ON state)
+
+// Layout
+kLabelWidth        = 100         // Fixed label width for alignment
+kGroupBoxMargin    = 8           // Margin inside group boxes
+kWidgetSpacing     = 6           // Vertical spacing between rows
+kSpinBoxWidth      = 120         // Minimum spinbox width
+
+// Fonts
+kStatusDotSize     = 12          // Status dot diameter (px)
+```
+
+---
+
+## Reusable Base Class: DevicePanel
+
+To enforce the uniform pattern, all panels inherit from a single `DevicePanel` base class:
+
+```cpp
+class DevicePanel : public QDockWidget {
+  Q_OBJECT
+public:
+  explicit DevicePanel(const QString& title,
+                       DeviceInterface* device,
+                       QWidget* parent = nullptr);
+
+protected:
+  // Subclasses override these to provide device-specific content
+  virtual QWidget* createControlsWidget() = 0;
+  virtual QWidget* createStatusWidget() = 0;
+
+  // Shared helpers available to all panels
+  QHBoxLayout* createLabeledSpinbox(const QString& label,
+                                     QDoubleSpinBox** out_spinbox,
+                                     double min, double max,
+                                     double step, int decimals,
+                                     const QString& suffix);
+
+  QHBoxLayout* createLabeledCombo(const QString& label,
+                                   QComboBox** out_combo,
+                                   const QStringList& items);
+
+  QPushButton* createToggleButton(const QString& on_text,
+                                   const QString& off_text);
+
+  QPushButton* createActionButton(const QString& text,
+                                   bool is_danger = false);
+
+  QHBoxLayout* createKeyValueRow(const QString& key,
+                                  QLabel** out_value);
+
+  // Connection section is built automatically by the base class
+  QComboBox* portCombo();
+  QComboBox* baudCombo();
+  QPushButton* connectButton();
+  QLabel* statusLabel();
+
+  // Access the device interface
+  DeviceInterface* device() const;
+
+private:
+  void buildConnectionSection();  // Identical for all panels
+  void updateConnectionState(DeviceInterface::DeviceState state);
+
+  DeviceInterface* device_;
+  QComboBox* port_combo_;
+  QComboBox* baud_combo_;
+  QPushButton* connect_button_;
+  QLabel* status_label_;
+  QLabel* status_dot_;
+};
+```
+
+### Why This Matters
+
+1. **Connection section** is built once in the base class — no duplication across 6 panels
+2. **Helper methods** ensure every spinbox, combo, button looks identical
+3. **Adding a new device** = subclass DevicePanel, implement `createControlsWidget()` + `createStatusWidget()`
+4. **GUI never changes for hardware** — panels bind to interface pointers, not concrete classes
+
+---
+
+## Interaction Rules (Same for All Panels)
+
+| Rule | Behavior |
+|------|----------|
+| **Connect flow** | User selects port → clicks Connect → button disables, shows "Connecting..." → on success: controls enable, status dot green → on error: status dot red with message |
+| **Disconnected state** | All controls in Controls section are **disabled**. Only Connection section is active. |
+| **Connected state** | All controls enabled. Connection section port/baud combos disabled (can't change while connected). |
+| **Error display** | Status dot turns red. Error message shown in status label. Controls remain enabled (user can retry). Log entry auto-generated. |
+| **Value echo** | When user changes a control (e.g., intensity slider), the GUI updates immediately. The Status section updates only when the device confirms via signal (e.g., `intensityChanged`). This means Controls show the *desired* value, Status shows the *confirmed* value. |
+| **Settings restore** | On panel construction, load last values from SettingsManager. Apply to controls but do NOT send to device (device not connected yet). |
+| **Settings save** | On every control change, save to SettingsManager. On window close, save window geometry/dock state. |

--- a/docs/hardware_data_flow.md
+++ b/docs/hardware_data_flow.md
@@ -1,0 +1,552 @@
+# Hardware Data Flow Architecture
+
+## Purpose
+
+This document defines the **exact data types, signal/slot contracts, and value ranges** for every device in the MWA system. The GUI panels are built against these contracts. When real hardware drivers replace mock controllers, **zero GUI changes** are needed.
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                         GUI Layer                            │
+│  ┌───────────┐ ┌───────────┐ ┌───────────┐ ┌──────────────┐ │
+│  │ LED Panel │ │Pump Panel │ │ SigGen    │ │ VNA Panel    │ │
+│  │           │ │           │ │ Panel     │ │              │ │
+│  └─────┬─────┘ └─────┬─────┘ └─────┬─────┘ └──────┬───────┘ │
+│  ┌─────┴─────┐ ┌─────┴──────────────┴─────┐ ┌─────┴───────┐ │
+│  │Camera Pan.│ │    Stage Panel            │ │Status Dashb.│ │
+│  └─────┬─────┘ └─────┬───────────────────┘ └──────┬───────┘ │
+│        │              │                            │         │
+└────────┼──────────────┼────────────────────────────┼─────────┘
+         │   Qt Signals/Slots (thread-safe)          │
+┌────────┼──────────────┼────────────────────────────┼─────────┐
+│        │      Hardware Abstraction Layer            │         │
+│  ┌─────▼─────┐ ┌─────▼─────┐ ┌───────────┐ ┌──────▼───────┐ │
+│  │LedCtrl    │ │StageCtrl  │ │PumpCtrl   │ │DeviceManager │ │
+│  │Interface  │ │Interface  │ │Interface  │ │  (singleton) │ │
+│  └─────┬─────┘ └─────┬─────┘ └─────┬─────┘ └──────────────┘ │
+│  ┌─────┴─────┐ ┌─────┴─────┐ ┌─────┴─────┐                  │
+│  │SigGenCtrl │ │VNACtrl    │ │CameraCtrl │                  │
+│  │Interface  │ │Interface  │ │Interface  │                  │
+│  └───────────┘ └───────────┘ └───────────┘                  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Rule:** GUI panels hold a pointer to the *interface* (e.g., `LedControllerInterface*`), never to a concrete implementation. Panels connect to interface signals and call interface slots. This is what makes the GUI hardware-agnostic.
+
+---
+
+## 1. LED Light Source (DEV-LED)
+
+### Real Hardware
+- **Device:** Thorlabs DC2200 / DC4100
+- **Protocol:** SCPI over USB-TMC (NI-VISA) or virtual serial port
+- **Key commands:** `OUTP ON/OFF`, `SOUR:BRIG <0-100>`, `SOUR:BRIG?`, `*IDN?`
+
+### Data Contract (LedControllerInterface)
+
+#### GUI → Hardware (User Actions)
+
+| Action | Method | Parameter Type | Range | Unit |
+|--------|--------|---------------|-------|------|
+| Turn on/off | `setPowerOn(bool)` | `bool` | true/false | — |
+| Set brightness | `setIntensity(double)` | `double` | 0.0 – 100.0 | percent |
+| Connect | `connectDevice()` | — | — | — |
+| Disconnect | `disconnectDevice()` | — | — | — |
+
+#### Hardware → GUI (Device Feedback)
+
+| Event | Signal | Parameter Type | Example Value |
+|-------|--------|---------------|---------------|
+| Power changed | `powerStateChanged(bool)` | `bool` | `true` |
+| Intensity changed | `intensityChanged(double)` | `double` | `75.0` |
+| State changed | `stateChanged(DeviceState)` | `DeviceState` enum | `kConnected` |
+| Error | `errorOccurred(QString)` | `QString` | `"Timeout on intensity set"` |
+
+#### GUI Panel Widgets
+
+| Widget | Type | Bound To | Notes |
+|--------|------|----------|-------|
+| Power toggle | `QPushButton` (checkable) | `setPowerOn()` / `powerStateChanged()` | Green=on, gray=off |
+| Intensity slider | `QSlider` (0–100) | `setIntensity()` / `intensityChanged()` | Horizontal, + spinbox |
+| Intensity spinbox | `QDoubleSpinBox` | Linked to slider | Range 0.0–100.0, step 0.1 |
+| Status indicator | `QLabel` with colored dot | `stateChanged()` | Green/yellow/red/gray |
+| Port selector | `QComboBox` | Serial port list | Populated from QSerialPortInfo |
+
+#### Mock Test Data
+
+```
+Connect → stateChanged(kConnecting) → stateChanged(kConnected)
+setPowerOn(true) → powerStateChanged(true)
+setIntensity(75.0) → intensityChanged(75.0)
+setPowerOn(false) → powerStateChanged(false)
+Disconnect → stateChanged(kDisconnected)
+```
+
+---
+
+## 2. Syringe Pump (DEV-PUMP)
+
+### Real Hardware
+- **Device:** Cetoni Nemesys
+- **Protocol:** Cetoni QmixSDK C API (compiled, not text-based)
+- **Key functions:** `LCP_Dispense()`, `LCP_Aspirate()`, `LCP_GenerateFlow()`, `LCP_GetFillLevel()`
+- **Units (SDK):** Configurable — typically µL for volume, µL/min for flow rate
+
+### Data Contract (PumpControllerInterface)
+
+#### GUI → Hardware (User Actions)
+
+| Action | Method | Parameter Type | Range | Unit |
+|--------|--------|---------------|-------|------|
+| Set flow rate | `setFlowRate(double)` | `double` | 0.001 – 100.0 | µL/min |
+| Set target volume | `setTargetVolume(double)` | `double` | 0.0 – 50000.0 | µL |
+| Start infusion | `startInfusion()` | — | — | — |
+| Stop infusion | `stopInfusion()` | — | — | — |
+| Refill syringe | `refill()` | — | — | — |
+| Connect | `connectDevice()` | — | — | — |
+| Disconnect | `disconnectDevice()` | — | — | — |
+
+#### Hardware → GUI (Device Feedback)
+
+| Event | Signal | Parameter Type | Example Value |
+|-------|--------|---------------|---------------|
+| Flow rate confirmed | `flowRateChanged(double)` | `double` | `5.0` |
+| Syringe position | `positionChanged(double)` | `double` | `123.4` (µL dispensed) |
+| Infusion started | `infusionStarted()` | — | — |
+| Infusion stopped | `infusionStopped()` | — | — |
+| State changed | `stateChanged(DeviceState)` | `DeviceState` | `kConnected` |
+| Error | `errorOccurred(QString)` | `QString` | `"Syringe empty"` |
+
+#### GUI Panel Widgets
+
+| Widget | Type | Bound To | Notes |
+|--------|------|----------|-------|
+| Flow rate input | `QDoubleSpinBox` | `setFlowRate()` / `flowRateChanged()` | Range 0.001–100.0, suffix " µL/min" |
+| Volume input | `QDoubleSpinBox` | `setTargetVolume()` | Range 0.0–50000.0, suffix " µL" |
+| Start button | `QPushButton` | `startInfusion()` | Disabled while infusing |
+| Stop button | `QPushButton` | `stopInfusion()` | Disabled while idle |
+| Refill button | `QPushButton` | `refill()` | Disabled while infusing |
+| Progress bar | `QProgressBar` | `positionChanged()` | Shows dispensed/target ratio |
+| Status indicator | `QLabel` | `stateChanged()` | Connected/Infusing/Idle/Error |
+| Flow rate display | `QLabel` | `flowRateChanged()` | Read-only current rate |
+
+#### Mock Test Data
+
+```
+Connect → stateChanged(kConnected)
+setFlowRate(5.0) → flowRateChanged(5.0)
+setTargetVolume(100.0)
+startInfusion() → infusionStarted()
+  → positionChanged(0.0)   (t=0s)
+  → positionChanged(25.0)  (t=5min)
+  → positionChanged(50.0)  (t=10min)
+  → positionChanged(75.0)  (t=15min)
+  → positionChanged(100.0) (t=20min)
+  → infusionStopped()      (target reached)
+```
+
+---
+
+## 3. Frequency / Signal Generator (DEV-SIGGEN)
+
+### Real Hardware
+- **Devices:** Rigol DG1062Z, Keysight 33500B, Tektronix AFG1022, etc.
+- **Protocol:** SCPI over USB-TMC, LAN (TCP:5025), or serial
+- **Key commands:** `SOUR:FREQ`, `SOUR:VOLT:AMPL`, `SOUR:FUNC`, `OUTP ON/OFF`
+
+### Data Contract (SignalGeneratorControllerInterface)
+
+#### GUI → Hardware (User Actions)
+
+| Action | Method | Parameter Type | Range | Unit |
+|--------|--------|---------------|-------|------|
+| Set frequency | `setFrequency(double)` | `double` | 0.1 – 120,000,000.0 | Hz |
+| Set amplitude | `setAmplitude(double)` | `double` | 0.01 – 20.0 | Vpp |
+| Set waveform | `setWaveform(Waveform)` | `Waveform` enum | kSine, kSquare, kTriangle | — |
+| Enable output | `setOutputEnabled(bool)` | `bool` | true/false | — |
+| Configure sweep | `configureSweep(double, double, double)` | `double` × 3 | start_hz, stop_hz, step_hz | Hz |
+| Connect | `connectDevice()` | — | — | — |
+| Disconnect | `disconnectDevice()` | — | — | — |
+
+#### Hardware → GUI (Device Feedback)
+
+| Event | Signal | Parameter Type | Example Value |
+|-------|--------|---------------|---------------|
+| Frequency confirmed | `frequencyChanged(double)` | `double` | `1000000.0` |
+| Amplitude confirmed | `amplitudeChanged(double)` | `double` | `2.5` |
+| Waveform confirmed | `waveformChanged(Waveform)` | `Waveform` | `kSine` |
+| Output state | `outputStateChanged(bool)` | `bool` | `true` |
+| State changed | `stateChanged(DeviceState)` | `DeviceState` | `kConnected` |
+| Error | `errorOccurred(QString)` | `QString` | `"Frequency out of range"` |
+
+#### GUI Panel Widgets
+
+| Widget | Type | Bound To | Notes |
+|--------|------|----------|-------|
+| Frequency input | `QDoubleSpinBox` | `setFrequency()` / `frequencyChanged()` | Suffix " Hz", adaptive step (1/10/100/1k/10k) |
+| Frequency unit selector | `QComboBox` | Multiplier for spinbox | Hz, kHz, MHz |
+| Amplitude input | `QDoubleSpinBox` | `setAmplitude()` / `amplitudeChanged()` | Range 0.01–20.0, suffix " Vpp" |
+| Waveform selector | `QComboBox` | `setWaveform()` / `waveformChanged()` | Sine, Square, Triangle |
+| Output toggle | `QPushButton` (checkable) | `setOutputEnabled()` / `outputStateChanged()` | Red=active, gray=off |
+| Sweep start | `QDoubleSpinBox` | `configureSweep()` | Hz |
+| Sweep stop | `QDoubleSpinBox` | `configureSweep()` | Hz |
+| Sweep step | `QDoubleSpinBox` | `configureSweep()` | Hz |
+| Status indicator | `QLabel` | `stateChanged()` | Connection state |
+
+#### Mock Test Data
+
+```
+Connect → stateChanged(kConnected)
+setFrequency(1000000.0) → frequencyChanged(1000000.0)
+setAmplitude(2.5) → amplitudeChanged(2.5)
+setWaveform(kSine) → waveformChanged(kSine)
+setOutputEnabled(true) → outputStateChanged(true)
+configureSweep(500000, 2000000, 10000)
+```
+
+---
+
+## 4. Vector Network Analyzer (DEV-VNA)
+
+### Real Hardware
+- **Devices:** Keysight E5080A, R&S ZNB/ZVA, miniVNA
+- **Protocol:** SCPI over USB-TMC, LAN (TCP:5025), or GPIB
+- **Key commands:** `SENS:FREQ:STAR/STOP`, `SENS:SWE:POIN`, `CALC:DATA? FDATA/SDATA`
+
+### Data Contract (NetworkAnalyzerControllerInterface)
+
+#### GUI → Hardware (User Actions)
+
+| Action | Method | Parameter Type | Range | Unit |
+|--------|--------|---------------|-------|------|
+| Set freq range | `setFrequencyRange(double, double)` | `double` × 2 | 100,000 – 8,500,000,000 | Hz |
+| Set num points | `setNumPoints(int)` | `int` | 2 – 32001 | — |
+| Start measurement | `measureSParameters()` | — | — | — |
+| Connect | `connectDevice()` | — | — | — |
+| Disconnect | `disconnectDevice()` | — | — | — |
+
+#### Hardware → GUI (Device Feedback)
+
+| Event | Signal | Parameter Type | Example Value |
+|-------|--------|---------------|---------------|
+| Measurement started | `measurementStarted()` | — | — |
+| Measurement complete | `measurementComplete()` | — | — |
+| Freq range changed | `frequencyRangeChanged(double, double)` | `double` × 2 | `1e9, 5e9` |
+| Num points changed | `numPointsChanged(int)` | `int` | `201` |
+| State changed | `stateChanged(DeviceState)` | `DeviceState` | `kConnected` |
+| Error | `errorOccurred(QString)` | `QString` | `"Measurement timeout"` |
+
+#### Data Retrieval (after measurementComplete)
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `traceFrequencies()` | `QVector<double>` | Frequency values for each sweep point (Hz) |
+| `traceMagnitudes()` | `QVector<double>` | S-parameter magnitude at each point (dB) |
+
+#### GUI Panel Widgets
+
+| Widget | Type | Bound To | Notes |
+|--------|------|----------|-------|
+| Start freq | `QDoubleSpinBox` | `setFrequencyRange()` | Suffix " Hz", with unit selector |
+| Stop freq | `QDoubleSpinBox` | `setFrequencyRange()` | Suffix " Hz", with unit selector |
+| Freq unit selector | `QComboBox` | Multiplier | kHz, MHz, GHz |
+| Num points | `QSpinBox` | `setNumPoints()` | Range 2–32001, default 201 |
+| Measure button | `QPushButton` | `measureSParameters()` | Disabled while measuring |
+| S-param plot | `QChartView` (QtCharts) | `traceFrequencies()` + `traceMagnitudes()` | X=freq, Y=dB |
+| Status indicator | `QLabel` | `stateChanged()` | Connection + measurement state |
+| Progress | `QLabel` | `measurementStarted/Complete()` | "Measuring..." / "Ready" |
+
+#### Mock Test Data
+
+```
+setFrequencyRange(1e9, 5e9) → frequencyRangeChanged(1e9, 5e9)
+setNumPoints(201) → numPointsChanged(201)
+measureSParameters() → measurementStarted()
+  (simulate 2-second sweep)
+  → measurementComplete()
+
+traceFrequencies() → [1.0e9, 1.02e9, 1.04e9, ..., 5.0e9]  (201 values)
+traceMagnitudes()  → [-45.2, -42.1, -39.8, ..., -38.5]      (201 values, dB)
+
+// Mock generates a realistic S21 curve: a resonance dip near 2 MHz
+// resembling PZT transducer response
+```
+
+---
+
+## 5. Camera (DEV-CAM)
+
+### Real Hardware
+- **Device:** Basler area-scan camera (ace/ace2 series)
+- **Protocol:** Basler Pylon C++ SDK (GenICam, not serial)
+- **Key classes:** `CInstantCamera`, `CGrabResultPtr`
+- **Unit conversions:** MWA exposure in ms → Pylon in µs (×1000); MWA gain linear → Pylon gain in dB
+
+### Data Contract (CameraControllerInterface)
+
+#### GUI → Hardware (User Actions)
+
+| Action | Method | Parameter Type | Range | Unit |
+|--------|--------|---------------|-------|------|
+| Set exposure | `setExposure(double)` | `double` | 0.01 – 10000.0 | ms |
+| Set gain | `setGain(double)` | `double` | 0.0 – 24.0 | dB |
+| Set ROI | `setRoi(QRect)` | `QRect` | x,y: 0–max; w,h: 1–max | pixels |
+| Grab single | `grabSingle()` | — | — | — |
+| Start continuous | `startContinuousCapture()` | — | — | — |
+| Stop capture | `stopCapture()` | — | — | — |
+| Start batch | `startBatchCapture(int, int)` | `int` × 2 | count: 1–10000, interval: 0–60000 | count, ms |
+| Connect | `connectDevice()` | — | — | — |
+| Disconnect | `disconnectDevice()` | — | — | — |
+
+#### Hardware → GUI (Device Feedback)
+
+| Event | Signal | Parameter Type | Example Value |
+|-------|--------|---------------|---------------|
+| Frame ready | `frameReady(QImage)` | `QImage` | 640×480 grayscale image |
+| Batch complete | `batchComplete()` | — | — |
+| Exposure changed | `exposureChanged(double)` | `double` | `25.0` (ms) |
+| Gain changed | `gainChanged(double)` | `double` | `6.0` (dB) |
+| State changed | `stateChanged(DeviceState)` | `DeviceState` | `kConnected` |
+| Error | `errorOccurred(QString)` | `QString` | `"Grab timeout"` |
+
+#### GUI Panel Widgets
+
+| Widget | Type | Bound To | Notes |
+|--------|------|----------|-------|
+| Live preview | `QLabel` (with QPixmap) | `frameReady()` | Scaled to fit, aspect ratio preserved |
+| Exposure input | `QDoubleSpinBox` | `setExposure()` / `exposureChanged()` | Range 0.01–10000, suffix " ms" |
+| Gain input | `QDoubleSpinBox` | `setGain()` / `gainChanged()` | Range 0.0–24.0, suffix " dB" |
+| ROI X | `QSpinBox` | `setRoi()` | 0 to sensor width |
+| ROI Y | `QSpinBox` | `setRoi()` | 0 to sensor height |
+| ROI Width | `QSpinBox` | `setRoi()` | 1 to sensor width |
+| ROI Height | `QSpinBox` | `setRoi()` | 1 to sensor height |
+| Grab single btn | `QPushButton` | `grabSingle()` | Disabled while capturing |
+| Continuous btn | `QPushButton` (checkable) | `startContinuousCapture()` / `stopCapture()` | Toggle |
+| Batch count | `QSpinBox` | `startBatchCapture()` | Range 1–10000 |
+| Batch interval | `QSpinBox` | `startBatchCapture()` | Range 0–60000, suffix " ms" |
+| Batch start btn | `QPushButton` | `startBatchCapture()` | |
+| Batch progress | `QProgressBar` | Count frames via `frameReady()` | 0 to batch count |
+| Status indicator | `QLabel` | `stateChanged()` | Connection state |
+
+#### Mock Test Data
+
+```
+Connect → stateChanged(kConnected)
+setExposure(25.0) → exposureChanged(25.0)
+setGain(6.0) → gainChanged(6.0)
+setRoi(QRect(0, 0, 640, 480))
+grabSingle() → frameReady(QImage(640, 480, Format_Grayscale8))
+startContinuousCapture()
+  → frameReady(frame1)  (every ~40ms for 25fps)
+  → frameReady(frame2)
+  → ...
+stopCapture()
+startBatchCapture(10, 500)
+  → frameReady(frame1) ... frameReady(frame10) → batchComplete()
+```
+
+Mock frames: synthetic gradient or noise pattern, 640×480 Grayscale8.
+
+---
+
+## 6. Motorized XYZ Stage (DEV-STAGE)
+
+### Real Hardware
+- **Devices:** Zaber X-series, ASI MS-2000, Prior ProScan III
+- **Protocols:** Zaber ASCII (`/1 move abs <steps>`), ASI (`M X=<pos>`, `W X Y Z`), Prior ProScan
+- **Unit conversions:** MWA uses mm; Zaber uses microsteps; ASI uses 0.1µm units (×10000 for mm)
+
+### Data Contract (StageControllerInterface)
+
+#### GUI → Hardware (User Actions)
+
+| Action | Method | Parameter Type | Range | Unit |
+|--------|--------|---------------|-------|------|
+| Home all axes | `home()` | — | — | — |
+| Move absolute | `moveAbsolute(double, double, double)` | `double` × 3 | -100.0 – 100.0 | mm |
+| Move relative | `moveRelative(double, double, double)` | `double` × 3 | -100.0 – 100.0 | mm |
+| Stop motion | `stopMotion()` | — | — | — |
+| Set speed | `setSpeed(double)` | `double` | 0.001 – 10.0 | mm/s |
+| Connect | `connectDevice()` | — | — | — |
+| Disconnect | `disconnectDevice()` | — | — | — |
+
+#### Hardware → GUI (Device Feedback)
+
+| Event | Signal | Parameter Type | Example Value |
+|-------|--------|---------------|---------------|
+| Position update | `positionChanged(double, double, double)` | `double` × 3 | `12.5, 8.3, 0.15` (mm) |
+| Home complete | `homeComplete()` | — | — |
+| Move complete | `moveComplete()` | — | — |
+| Speed changed | `speedChanged(double)` | `double` | `2.0` (mm/s) |
+| State changed | `stateChanged(DeviceState)` | `DeviceState` | `kConnected` |
+| Error | `errorOccurred(QString)` | `QString` | `"Axis X limit reached"` |
+
+#### GUI Panel Widgets
+
+| Widget | Type | Bound To | Notes |
+|--------|------|----------|-------|
+| X position display | `QLabel` or `QLCDNumber` | `positionChanged()` | 3 decimal places, suffix " mm" |
+| Y position display | `QLabel` or `QLCDNumber` | `positionChanged()` | Same |
+| Z position display | `QLabel` or `QLCDNumber` | `positionChanged()` | Same |
+| X target input | `QDoubleSpinBox` | `moveAbsolute()` | Range -100.0–100.0 |
+| Y target input | `QDoubleSpinBox` | `moveAbsolute()` | Same |
+| Z target input | `QDoubleSpinBox` | `moveAbsolute()` | Same |
+| Go button | `QPushButton` | `moveAbsolute()` | Reads X/Y/Z inputs |
+| Jog buttons (±X,±Y,±Z) | 6 × `QPushButton` | `moveRelative()` | Step size from spinbox |
+| Jog step size | `QDoubleSpinBox` | Used by jog buttons | Default 0.1 mm |
+| Home button | `QPushButton` | `home()` | Disabled while moving |
+| Stop button | `QPushButton` | `stopMotion()` | Always enabled, red |
+| Speed input | `QDoubleSpinBox` | `setSpeed()` / `speedChanged()` | Range 0.001–10.0, suffix " mm/s" |
+| Moving indicator | `QLabel` | `isMoving()` | "Moving..." or "Idle" |
+| Status indicator | `QLabel` | `stateChanged()` | Connection state |
+
+#### Mock Test Data
+
+```
+Connect → stateChanged(kConnected)
+home() → positionChanged(0.0, 0.0, 0.0) → homeComplete()
+setSpeed(2.0) → speedChanged(2.0)
+moveAbsolute(10.0, 5.0, 1.0)
+  → positionChanged(2.0, 1.0, 0.2)   (interpolated)
+  → positionChanged(5.0, 2.5, 0.5)
+  → positionChanged(10.0, 5.0, 1.0)  → moveComplete()
+moveRelative(-1.0, 0.0, 0.0)
+  → positionChanged(9.0, 5.0, 1.0) → moveComplete()
+stopMotion() → (immediate stop at current position)
+```
+
+---
+
+## 7. Device Status Dashboard (GUI-REQ-007)
+
+The dashboard aggregates state from **all** devices via `DeviceManager`.
+
+### Data Sources
+
+| Source | Signal | Data |
+|--------|--------|------|
+| DeviceManager | `deviceRegistered(DeviceType)` | New device available |
+| DeviceManager | `deviceRemoved(DeviceType)` | Device removed |
+| DeviceManager | `deviceStateChanged(DeviceType, DeviceState)` | Connection state change |
+| DeviceManager | `deviceError(DeviceType, QString)` | Error from any device |
+
+### Dashboard Widgets
+
+| Widget | Type | Description |
+|--------|------|-------------|
+| Device list | `QTableWidget` or `QListWidget` | One row per registered device |
+| Status column | Color-coded `QLabel` per row | Green=connected, Yellow=connecting, Red=error, Gray=disconnected |
+| Name column | `QLabel` | Device name from `deviceName()` |
+| Connect All button | `QPushButton` | Calls `DeviceManager::connectAll()` |
+| Disconnect All button | `QPushButton` | Calls `DeviceManager::disconnectAll()` |
+
+---
+
+## 8. Logging Panel (GUI-REQ-009)
+
+### Data Source
+
+| Source | Signal | Data |
+|--------|--------|------|
+| Logger | `newLogEntry(LogEntry)` | timestamp, severity, source, message |
+
+### LogEntry Struct (already defined)
+
+```cpp
+struct LogEntry {
+  QDateTime timestamp;
+  LogSeverity severity;  // kDebug, kInfo, kWarning, kError
+  QString source;        // "LED", "Pump", "Stage", etc.
+  QString message;
+};
+```
+
+### Panel Widgets
+
+| Widget | Type | Description |
+|--------|------|-------------|
+| Log view | `QTableView` + `QStandardItemModel` | Scrolling log with columns: Time, Severity, Source, Message |
+| Severity filter | `QComboBox` or checkboxes | Filter by severity level |
+| Source filter | `QComboBox` | Filter by device source |
+| Clear button | `QPushButton` | Clear log entries |
+| Auto-scroll toggle | `QCheckBox` | Auto-scroll to latest entry |
+| Export button | `QPushButton` | Save log to file |
+
+---
+
+## 9. Settings Persistence (GUI-REQ-010)
+
+### Settings Groups and Keys
+
+| Group | Key | Type | Default | Description |
+|-------|-----|------|---------|-------------|
+| `LED` | `port_name` | `QString` | `""` | Last used serial port |
+| `LED` | `baud_rate` | `int` | `115200` | Baud rate |
+| `LED` | `intensity` | `double` | `50.0` | Last intensity |
+| `Pump` | `port_name` | `QString` | `""` | Last used port |
+| `Pump` | `flow_rate` | `double` | `1.0` | Last flow rate (µL/min) |
+| `Pump` | `target_volume` | `double` | `100.0` | Last target volume (µL) |
+| `SigGen` | `port_name` | `QString` | `""` | Last used port |
+| `SigGen` | `frequency` | `double` | `1000000.0` | Last frequency (Hz) |
+| `SigGen` | `amplitude` | `double` | `1.0` | Last amplitude (Vpp) |
+| `SigGen` | `waveform` | `int` | `0` | kSine=0, kSquare=1, kTriangle=2 |
+| `VNA` | `port_name` | `QString` | `""` | Last used port |
+| `VNA` | `start_freq` | `double` | `1e6` | Start frequency (Hz) |
+| `VNA` | `stop_freq` | `double` | `1e9` | Stop frequency (Hz) |
+| `VNA` | `num_points` | `int` | `201` | Sweep points |
+| `Camera` | `exposure` | `double` | `25.0` | Exposure (ms) |
+| `Camera` | `gain` | `double` | `0.0` | Gain (dB) |
+| `Camera` | `roi_x` | `int` | `0` | ROI X offset |
+| `Camera` | `roi_y` | `int` | `0` | ROI Y offset |
+| `Camera` | `roi_w` | `int` | `640` | ROI width |
+| `Camera` | `roi_h` | `int` | `480` | ROI height |
+| `Stage` | `port_name` | `QString` | `""` | Last used port |
+| `Stage` | `speed` | `double` | `1.0` | Speed (mm/s) |
+| `Stage` | `jog_step` | `double` | `0.1` | Jog step size (mm) |
+| `MainWindow` | `geometry` | `QByteArray` | — | Window size/position |
+| `MainWindow` | `state` | `QByteArray` | — | Dock widget layout |
+| `Log` | `severity_filter` | `int` | `0` | Min severity to display |
+| `Log` | `auto_scroll` | `bool` | `true` | Auto-scroll enabled |
+
+---
+
+## 10. Mock Controller Strategy
+
+Each device gets a `Mock<Device>Controller` that:
+1. **Implements the same interface** as the real controller
+2. **Simulates realistic timing** (delays, async responses)
+3. **Produces realistic data** (mock frames, S-parameter curves, position interpolation)
+4. **Validates parameter ranges** (same as real hardware would)
+5. **Can inject errors** for error-handling testing
+
+### Mock Classes Needed
+
+| Mock Class | Extends | Key Simulation |
+|------------|---------|----------------|
+| `MockLedController` | `LedControllerInterface` | Instant on/off, intensity echo |
+| `MockPumpController` | `PumpControllerInterface` | Timed dispensing, fill level decrement |
+| `MockSignalGeneratorController` | `SignalGeneratorControllerInterface` | Parameter echo, sweep timer |
+| `MockNetworkAnalyzerController` | `NetworkAnalyzerControllerInterface` | Generate synthetic S21 curve with resonance |
+| `MockCameraController` | `CameraControllerInterface` | Generate gradient/noise QImages |
+| `MockStageController` | `StageControllerInterface` | Interpolated position updates |
+
+---
+
+## 11. Unit Conversion Reference
+
+When real hardware is integrated, these conversions happen **inside the concrete controller**, not in the GUI.
+
+| Device | MWA Interface Unit | Real Hardware Unit | Conversion |
+|--------|-------------------|-------------------|------------|
+| Camera exposure | ms | µs (Pylon) | ×1000 |
+| Camera gain | dB | dB (Pylon) | none (already dB) |
+| LED intensity | percent (0–100) | percent or amps | depends on model |
+| Pump flow rate | µL/min | µL/min (QmixSDK) | none (SDK configurable) |
+| Pump volume | µL | µL (QmixSDK) | none |
+| SigGen frequency | Hz | Hz (SCPI) | none |
+| SigGen amplitude | Vpp | Vpp (SCPI) | none |
+| VNA frequency | Hz | Hz (SCPI) | none |
+| VNA magnitude | dB | dB (SCPI FDATA) | none |
+| Stage position | mm | microsteps (Zaber) or 0.1µm (ASI) | Zaber: ÷steps_per_mm; ASI: ÷10000 |
+| Stage speed | mm/s | device-specific | Zaber: ÷steps_per_mm; ASI: direct |

--- a/src/hardware/led/led_controller.cpp
+++ b/src/hardware/led/led_controller.cpp
@@ -102,22 +102,20 @@ void LedController::disconnectDevice() {
     if (state_ == DeviceState::kDisconnected) {
       return;
     }
+    // Transition state immediately so command guards reject new requests
+    // before the worker thread closes the port.
+    state_ = DeviceState::kDisconnected;
+    power_on_ = false;
+    intensity_ = 0.0;
   }
+  emit stateChanged(DeviceState::kDisconnected);
 
   command_queue_->enqueue([this]() {
     if (port_ && port_->isOpen()) {
       port_->close();
     }
-
     mwa::core::Logger::instance().logInfo(
         QStringLiteral("LedController: disconnected"));
-
-    {
-      QMutexLocker lock(&mutex_);
-      power_on_ = false;
-      intensity_ = 0.0;
-    }
-    setState(DeviceState::kDisconnected);
   });
 }
 

--- a/src/hardware/serial_utils.cpp
+++ b/src/hardware/serial_utils.cpp
@@ -29,6 +29,9 @@ QString sendCommand(QSerialPort* port, const QString& cmd,
   // not a total budget. Assumes the device sends its full response in one
   // chunk (one waitForReadyRead iteration), which holds for all supported
   // ASCII protocols that reply with a single \r\n-terminated line.
+  // TODO: Add a total-elapsed-time cap around the while-loop below so that
+  //       a non-compliant device trickling data cannot block indefinitely.
+  //       Needed when non-ASCII or multi-line protocols are introduced.
   if (!port->waitForBytesWritten(response_wait_ms)) {
     return {};
   }

--- a/src/hardware/serial_utils.cpp
+++ b/src/hardware/serial_utils.cpp
@@ -25,6 +25,10 @@ QString sendCommand(QSerialPort* port, const QString& cmd,
   const QByteArray data = (cmd + QStringLiteral("\r\n")).toUtf8();
   port->write(data);
 
+  // response_wait_ms is a per-operation timeout (write + each read cycle),
+  // not a total budget. Assumes the device sends its full response in one
+  // chunk (one waitForReadyRead iteration), which holds for all supported
+  // ASCII protocols that reply with a single \r\n-terminated line.
   if (!port->waitForBytesWritten(response_wait_ms)) {
     return {};
   }

--- a/src/hardware/stage/stage_controller.cpp
+++ b/src/hardware/stage/stage_controller.cpp
@@ -105,25 +105,23 @@ void StageController::disconnectDevice() {
     if (state_ == DeviceState::kDisconnected) {
       return;
     }
+    // Transition state immediately so command guards reject new requests
+    // before the worker thread closes the port.
+    state_ = DeviceState::kDisconnected;
+    position_x_ = 0.0;
+    position_y_ = 0.0;
+    position_z_ = 0.0;
+    speed_ = 1.0;
+    is_moving_ = false;
   }
+  emit stateChanged(DeviceState::kDisconnected);
 
   command_queue_->enqueue([this]() {
     if (port_ && port_->isOpen()) {
       port_->close();
     }
-
     mwa::core::Logger::instance().logInfo(
         QStringLiteral("StageController: disconnected"));
-
-    {
-      QMutexLocker lock(&mutex_);
-      position_x_ = 0.0;
-      position_y_ = 0.0;
-      position_z_ = 0.0;
-      speed_ = 1.0;
-      is_moving_ = false;
-    }
-    setState(DeviceState::kDisconnected);
   });
 }
 

--- a/src/hardware/stage/stage_controller.cpp
+++ b/src/hardware/stage/stage_controller.cpp
@@ -108,10 +108,10 @@ void StageController::disconnectDevice() {
     // Transition state immediately so command guards reject new requests
     // before the worker thread closes the port.
     state_ = DeviceState::kDisconnected;
-    position_x_ = 0.0;
-    position_y_ = 0.0;
-    position_z_ = 0.0;
-    speed_ = 1.0;
+    position_x_ = kDefaultPosition;
+    position_y_ = kDefaultPosition;
+    position_z_ = kDefaultPosition;
+    speed_ = kDefaultSpeed;
     is_moving_ = false;
   }
   emit stateChanged(DeviceState::kDisconnected);
@@ -153,10 +153,7 @@ void StageController::home() {
 
   command_queue_->enqueue(
       [this]() {
-        {
-          QMutexLocker lock(&mutex_);
-          is_moving_ = true;
-        }
+        MovingGuard guard(*this);
 
         const QString resp = serial_utils::sendCommand(
             port_.get(), QStringLiteral("HOME"), kResponseWaitMs);
@@ -164,18 +161,13 @@ void StageController::home() {
         if (serial_utils::isOkResponse(resp)) {
           {
             QMutexLocker lock(&mutex_);
-            position_x_ = 0.0;
-            position_y_ = 0.0;
-            position_z_ = 0.0;
-            is_moving_ = false;
+            position_x_ = kDefaultPosition;
+            position_y_ = kDefaultPosition;
+            position_z_ = kDefaultPosition;
           }
           emit positionChanged(0.0, 0.0, 0.0);
           emit homeComplete();
         } else {
-          {
-            QMutexLocker lock(&mutex_);
-            is_moving_ = false;
-          }
           const QString err = serial_utils::formatCommandError(
               QStringLiteral("StageController"),
               QStringLiteral("HOME"), resp);
@@ -196,10 +188,7 @@ void StageController::moveAbsolute(double x, double y, double z) {
 
   command_queue_->enqueue(
       [this, x, y, z]() {
-        {
-          QMutexLocker lock(&mutex_);
-          is_moving_ = true;
-        }
+        MovingGuard guard(*this);
 
         const QString cmd =
             QStringLiteral("MOVE %1 %2 %3")
@@ -216,15 +205,10 @@ void StageController::moveAbsolute(double x, double y, double z) {
             position_x_ = x;
             position_y_ = y;
             position_z_ = z;
-            is_moving_ = false;
           }
           emit positionChanged(x, y, z);
           emit moveComplete();
         } else {
-          {
-            QMutexLocker lock(&mutex_);
-            is_moving_ = false;
-          }
           const QString err = serial_utils::formatCommandError(
               QStringLiteral("StageController"),
               QStringLiteral("MOVE"), resp);
@@ -245,10 +229,7 @@ void StageController::moveRelative(double dx, double dy, double dz) {
 
   command_queue_->enqueue(
       [this, dx, dy, dz]() {
-        {
-          QMutexLocker lock(&mutex_);
-          is_moving_ = true;
-        }
+        MovingGuard guard(*this);
 
         const QString cmd =
             QStringLiteral("RMOVE %1 %2 %3")
@@ -271,15 +252,10 @@ void StageController::moveRelative(double dx, double dy, double dz) {
             new_x = position_x_;
             new_y = position_y_;
             new_z = position_z_;
-            is_moving_ = false;
           }
           emit positionChanged(new_x, new_y, new_z);
           emit moveComplete();
         } else {
-          {
-            QMutexLocker lock(&mutex_);
-            is_moving_ = false;
-          }
           const QString err = serial_utils::formatCommandError(
               QStringLiteral("StageController"),
               QStringLiteral("RMOVE"), resp);

--- a/src/hardware/stage/stage_controller.h
+++ b/src/hardware/stage/stage_controller.h
@@ -219,6 +219,41 @@ class StageController : public StageControllerInterface {
 
  private:
   /**
+   * @brief RAII guard that sets is_moving_ to true on construction
+   *        and false on destruction, both under mutex_.
+   *
+   * Used by home(), moveAbsolute(), and moveRelative() to guarantee
+   * is_moving_ is always reset even when the command fails.
+   */
+  class MovingGuard {
+   public:
+    /**
+     * @brief Construct a MovingGuard, setting is_moving_ = true.
+     *
+     * @param owner The StageController whose is_moving_ flag to manage.
+     */
+    explicit MovingGuard(StageController& owner) : owner_(owner) {
+      QMutexLocker lock(&owner_.mutex_);
+      owner_.is_moving_ = true;
+    }
+
+    /**
+     * @brief Destroy the MovingGuard, resetting is_moving_ = false.
+     */
+    ~MovingGuard() {
+      QMutexLocker lock(&owner_.mutex_);
+      owner_.is_moving_ = false;
+    }
+
+    // Non-copyable, non-movable.
+    MovingGuard(const MovingGuard&) = delete;
+    MovingGuard& operator=(const MovingGuard&) = delete;
+
+   private:
+    StageController& owner_;
+  };
+
+  /**
    * @brief Parse a position response of the form "x y z".
    *
    * @param response The trimmed response string.
@@ -250,12 +285,17 @@ class StageController : public StageControllerInterface {
   /// Created lazily on the worker thread; destroyed after shutdown().
   std::unique_ptr<QSerialPort> port_;
 
+  /// Default position for each axis on construction and disconnect.
+  static constexpr double kDefaultPosition = 0.0;
+  /// Default travel speed on construction and disconnect (mm/s).
+  static constexpr double kDefaultSpeed = 1.0;
+
   mutable QMutex mutex_;                        ///< Guards cached state.
   DeviceState state_{DeviceState::kDisconnected};  ///< Cached state.
-  double position_x_{0.0};                      ///< Cached X position.
-  double position_y_{0.0};                      ///< Cached Y position.
-  double position_z_{0.0};                      ///< Cached Z position.
-  double speed_{1.0};                           ///< Cached speed mm/s.
+  double position_x_{kDefaultPosition};         ///< Cached X position.
+  double position_y_{kDefaultPosition};         ///< Cached Y position.
+  double position_z_{kDefaultPosition};         ///< Cached Z position.
+  double speed_{kDefaultSpeed};                 ///< Cached speed mm/s.
   bool is_moving_{false};                       ///< Cached motion flag.
   QString port_name_;                           ///< Serial port name.
   qint32 baud_rate_{115200};                    ///< Serial baud rate.

--- a/tests/test_led_controller.cpp
+++ b/tests/test_led_controller.cpp
@@ -41,6 +41,8 @@ class TestLedController : public QObject {
 
   // -- C. Connected-state guards --------------------------------------------
   void test_setIntensity_noOpWhenDisconnected();
+  void test_setIntensity_clampBelow_noOpWhenDisconnected();
+  void test_setIntensity_clampAbove_noOpWhenDisconnected();
   void test_setPowerOn_noOpWhenDisconnected();
   void test_disconnectDevice_noOpWhenAlreadyDisconnected();
 };
@@ -106,6 +108,30 @@ void TestLedController::test_setIntensity_noOpWhenDisconnected() {
   QTest::qWait(100);
 
   // No signal emitted — command was not enqueued.
+  QCOMPARE(spy.count(), 0);
+  QCOMPARE(ctrl.intensity(), 0.0);
+}
+
+void TestLedController::test_setIntensity_clampBelow_noOpWhenDisconnected() {
+  LedController ctrl;
+  QSignalSpy spy(&ctrl, &LedController::intensityChanged);
+
+  // Clamped to 0.0 — same as initial intensity, and device is disconnected.
+  ctrl.setIntensity(-10.0);
+  QTest::qWait(100);
+
+  QCOMPARE(spy.count(), 0);
+  QCOMPARE(ctrl.intensity(), 0.0);
+}
+
+void TestLedController::test_setIntensity_clampAbove_noOpWhenDisconnected() {
+  LedController ctrl;
+  QSignalSpy spy(&ctrl, &LedController::intensityChanged);
+
+  // Clamped to 100.0 — device is disconnected, so no command is enqueued.
+  ctrl.setIntensity(150.0);
+  QTest::qWait(100);
+
   QCOMPARE(spy.count(), 0);
   QCOMPARE(ctrl.intensity(), 0.0);
 }

--- a/tests/test_led_controller.cpp
+++ b/tests/test_led_controller.cpp
@@ -41,8 +41,8 @@ class TestLedController : public QObject {
 
   // -- C. Connected-state guards --------------------------------------------
   void test_setIntensity_noOpWhenDisconnected();
-  void test_setIntensity_clampBelow_noOpWhenDisconnected();
-  void test_setIntensity_clampAbove_noOpWhenDisconnected();
+  void test_setIntensity_belowRange_noOpWhenDisconnected();
+  void test_setIntensity_aboveRange_noOpWhenDisconnected();
   void test_setPowerOn_noOpWhenDisconnected();
   void test_disconnectDevice_noOpWhenAlreadyDisconnected();
 };
@@ -112,11 +112,12 @@ void TestLedController::test_setIntensity_noOpWhenDisconnected() {
   QCOMPARE(ctrl.intensity(), 0.0);
 }
 
-void TestLedController::test_setIntensity_clampBelow_noOpWhenDisconnected() {
+void TestLedController::test_setIntensity_belowRange_noOpWhenDisconnected() {
   LedController ctrl;
   QSignalSpy spy(&ctrl, &LedController::intensityChanged);
 
-  // Clamped to 0.0 — same as initial intensity, and device is disconnected.
+  // Below-range value — device is disconnected, so the guard rejects
+  // before clamping is ever reached.
   ctrl.setIntensity(-10.0);
   QTest::qWait(100);
 
@@ -124,11 +125,12 @@ void TestLedController::test_setIntensity_clampBelow_noOpWhenDisconnected() {
   QCOMPARE(ctrl.intensity(), 0.0);
 }
 
-void TestLedController::test_setIntensity_clampAbove_noOpWhenDisconnected() {
+void TestLedController::test_setIntensity_aboveRange_noOpWhenDisconnected() {
   LedController ctrl;
   QSignalSpy spy(&ctrl, &LedController::intensityChanged);
 
-  // Clamped to 100.0 — device is disconnected, so no command is enqueued.
+  // Above-range value — device is disconnected, so the guard rejects
+  // before clamping is ever reached.
   ctrl.setIntensity(150.0);
   QTest::qWait(100);
 

--- a/tests/test_serial_utils.cpp
+++ b/tests/test_serial_utils.cpp
@@ -93,13 +93,15 @@ void TestSerialUtils::test_formatCommandError_emptyResponse() {
 }
 
 void TestSerialUtils::test_formatCommandError_whitespaceResponse() {
-  // Non-empty whitespace is NOT treated as timeout.
+  // formatCommandError tests isEmpty(), not isNull() — a whitespace string
+  // is non-empty so it is used verbatim. Note: sendCommand() always trims
+  // its return value, so a whitespace-only string cannot arrive from the
+  // normal pipeline; this exercises formatCommandError in isolation.
   const QString result = utils::formatCommandError(
       QStringLiteral("Driver"),
       QStringLiteral("CMD"),
       QStringLiteral(" "));
 
-  QVERIFY(result.contains(QStringLiteral(" ")));
   QVERIFY(!result.contains(QStringLiteral("timeout")));
 }
 


### PR DESCRIPTION
## Summary
- **Serial utilities** (`serial_utils.h/.cpp`): `sendCommand()` for write/read with configurable timeout, plus `formatCommandError()` helper. Used by both LED and Stage controllers.
- **LedController**: Qt-based async LED driver with intensity (0–100%), power on/off, serial connect/disconnect. Commands run on a dedicated worker thread via `CommandQueue`.
- **StageController**: Qt-based async 3-axis stage driver with absolute/relative moves, homing, speed control. Same `CommandQueue` pattern as LED.
- **Disconnect race fix**: Both controllers now reset state immediately under the mutex (before the worker thread runs) to prevent commands sneaking in during the disconnect window.
- **Workflow streamlining**: Updated CLAUDE.md, lead agent, and workflow docs so the Lead→SWE→TE→PR chain runs continuously without intermediate "go on" pauses.
- **Docs**: Added `docs/gui_design_spec.md` (GUI Phase 1 design) and `docs/hardware_data_flow.md` (hardware↔GUI data contracts).

## What changed
| File | Change |
|---|---|
| `src/hardware/serial_utils.h/.cpp` | New — serial send/receive + error formatting |
| `src/hardware/led/led_controller.h/.cpp` | New — async LED controller |
| `src/hardware/stage/stage_controller.h/.cpp` | New — async 3-axis stage controller |
| `tests/test_serial_utils.cpp` | New — 7 unit tests for serial utilities |
| `tests/test_led_controller.cpp` | New — 8 unit tests for LED controller |
| `tests/test_stage_controller.cpp` | New — 8 unit tests for stage controller |
| `src/hardware/CMakeLists.txt` | New — hardware library build config |
| `tests/CMakeLists.txt` | New — test targets build config |
| `docs/gui_design_spec.md` | New — GUI Phase 1 design spec |
| `docs/hardware_data_flow.md` | New — hardware↔GUI data contracts |
| `.claude/agents/lead.md` | Updated — continuous workflow |
| `.claude/workflows/development_workflow.md` | Updated — continuous workflow |
| `CLAUDE.md` | Updated — continuous workflow rules |

## Handoff Summary
### What to test
- **Build**: `cmake --build build` should compile with zero warnings on both macOS and Windows.
- **Unit tests**: `ctest --test-dir build` — all 23 tests (serial + LED + stage) should pass.
- **Code review focus**:
  - `disconnectDevice()` in both controllers — verify the early state reset under mutex is correct and the `stateChanged` signal fires before the port-close lambda.
  - `sendCommand()` timeout semantics — the comment explains the per-op timeout assumption.
  - Doxygen completeness on all public APIs in the 3 new header files.

### What NOT to worry about
- No hardware needed — all tests use mock/disconnected paths.
- Workflow doc changes are process-only, no code impact.

## Test plan
- [ ] CI passes on both macOS and Windows
- [ ] All unit tests pass (`ctest --test-dir build`)
- [ ] Zero compiler warnings
- [ ] Doxygen comments present on all public APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)