### PR TITLE
MWA-Wave3: Driver skeletons (Pump + Signal Generator)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,15 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
+# Custom CMake modules (FindQmixSDK, FindPylon, etc.)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 # Find Qt6
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Test)
 find_package(Qt6 OPTIONAL_COMPONENTS SerialPort)
+
+# Optional vendor SDKs (only available on specific platforms)
+find_package(QmixSDK QUIET)
 
 # Testing
 include(CTest)

--- a/cmake/FindQmixSDK.cmake
+++ b/cmake/FindQmixSDK.cmake
@@ -1,0 +1,81 @@
+# FindQmixSDK.cmake -- Locate the Cetoni QmixSDK C API
+#
+# This module finds the Cetoni QmixSDK libraries and headers needed to
+# build the real PumpController driver.  The SDK provides a C API for
+# controlling Nemesys syringe pumps over a CAN bus.
+#
+# Sets:
+#   QmixSDK_FOUND         - TRUE if SDK found
+#   QmixSDK_INCLUDE_DIRS  - Header search paths
+#   QmixSDK_LIBRARIES     - Libraries to link
+#
+# Imported target:
+#   QmixSDK::QmixSDK      - UNKNOWN IMPORTED library (when found)
+#
+# Hints:
+#   QMIXSDK_ROOT environment variable or CMake variable
+#
+# Platform notes:
+#   - Windows: Full SDK support (primary development platform)
+#   - Linux:   SDK available since ~2022
+#   - macOS:   SDK not available — this module sets QmixSDK_FOUND=FALSE
+#
+# See also: docs/protocols/cetoni_nemesys_spec.md
+
+# ── macOS early-out ────────────────────────────────────────────
+if(APPLE)
+  set(QmixSDK_FOUND FALSE)
+  if(NOT QmixSDK_FIND_QUIETLY)
+    message(STATUS "FindQmixSDK: QmixSDK is not available on macOS")
+  endif()
+  return()
+endif()
+
+# ── Search paths ───────────────────────────────────────────────
+set(_qmix_search_paths
+  "$ENV{QMIXSDK_ROOT}"
+  "${QMIXSDK_ROOT}"
+  "C:/QmixSDK"
+  "C:/Program Files/CETONI/QmixSDK"
+  "C:/Program Files (x86)/CETONI/QmixSDK"
+  "/opt/cetoni/qmixsdk"
+  "$ENV{HOME}/QmixSDK"
+)
+
+# ── Find header ────────────────────────────────────────────────
+find_path(QmixSDK_INCLUDE_DIR
+  NAMES lcp.h
+  PATHS ${_qmix_search_paths}
+  PATH_SUFFIXES include lib/qmixsdk
+)
+
+# ── Find library ───────────────────────────────────────────────
+find_library(QmixSDK_LIBRARY
+  NAMES qmixsdk lcp
+  PATHS ${_qmix_search_paths}
+  PATH_SUFFIXES lib lib64
+)
+
+# ── Standard find-package handling ─────────────────────────────
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(QmixSDK
+  DEFAULT_MSG
+  QmixSDK_INCLUDE_DIR
+  QmixSDK_LIBRARY
+)
+
+# ── Create imported target ─────────────────────────────────────
+if(QmixSDK_FOUND)
+  set(QmixSDK_INCLUDE_DIRS "${QmixSDK_INCLUDE_DIR}")
+  set(QmixSDK_LIBRARIES "${QmixSDK_LIBRARY}")
+
+  if(NOT TARGET QmixSDK::QmixSDK)
+    add_library(QmixSDK::QmixSDK UNKNOWN IMPORTED)
+    set_target_properties(QmixSDK::QmixSDK PROPERTIES
+      IMPORTED_LOCATION "${QmixSDK_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${QmixSDK_INCLUDE_DIR}"
+    )
+  endif()
+endif()
+
+mark_as_advanced(QmixSDK_INCLUDE_DIR QmixSDK_LIBRARY)

--- a/src/hardware/CMakeLists.txt
+++ b/src/hardware/CMakeLists.txt
@@ -63,3 +63,13 @@ if(TARGET Qt6::SerialPort)
   target_link_libraries(MwaHardware PUBLIC Qt6::SerialPort)
   target_compile_definitions(MwaHardware PUBLIC MWA_HAS_SERIAL_PORT)
 endif()
+
+# Cetoni Nemesys pump driver — requires QmixSDK (Windows/Linux only)
+if(QmixSDK_FOUND)
+  target_sources(MwaHardware PRIVATE
+    pump/pump_controller.h
+    pump/pump_controller.cpp
+  )
+  target_link_libraries(MwaHardware PRIVATE QmixSDK::QmixSDK)
+  target_compile_definitions(MwaHardware PRIVATE MWA_HAS_QMIXSDK)
+endif()

--- a/src/hardware/pump/pump_controller.h
+++ b/src/hardware/pump/pump_controller.h
@@ -1,0 +1,420 @@
+/**
+ * @file pump_controller.h
+ * @brief Hardware syringe pump driver skeleton for the Cetoni Nemesys system.
+ * @author onuronarici
+ * @date 2026-04-04
+ *
+ * Declares the PumpController class, which wraps the Cetoni QmixSDK C API
+ * to drive Nemesys syringe pump modules over a CAN bus (USB-to-CAN adapter).
+ * All SDK calls are serialised through a CommandQueue running on a dedicated
+ * worker thread.
+ *
+ * This is a **header-only skeleton** — the .cpp implementation will be written
+ * when the Cetoni hardware and QmixSDK become available.  The header is fully
+ * documented so that the implementation can be written directly from the
+ * Doxygen comments and the protocol specification in
+ * `docs/protocols/cetoni_nemesys_spec.md`.
+ *
+ * @note QmixSDK is only available on Windows and Linux.  On macOS this file
+ *       is included in the build (so it compiles), but no .cpp is compiled.
+ *       The GUI always works against PumpControllerInterface*, so the mock is
+ *       used on unsupported platforms.
+ *
+ * @see PumpControllerInterface
+ * @see CommandQueue
+ * @see MockPumpController
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <QMutex>
+#include <QString>
+#include <QTimer>
+
+#include <cstdint>
+#include <memory>
+
+#include "hardware/command_queue.h"
+#include "hardware/pump/pump_controller_interface.h"
+
+namespace mwa::hardware {
+
+/**
+ * @brief Opaque SDK handle type matching Cetoni's `dev_hdl` (long long).
+ *
+ * Using a typedef keeps the header independent of the QmixSDK headers,
+ * which may not be available at build time on all platforms.
+ */
+using QmixDeviceHandle = int64_t;
+
+/// Invalid / uninitialised device handle sentinel.
+inline constexpr QmixDeviceHandle kInvalidQmixHandle = -1;
+
+/// Default polling interval (ms) for position updates during infusion.
+inline constexpr int kPumpPollIntervalMs = 100;
+
+/// Default per-command timeout for SDK operations (ms).
+inline constexpr int kPumpCommandTimeoutMs = 5000;
+
+/// Timeout for the multi-step connect sequence (ms).
+inline constexpr int kPumpConnectTimeoutMs = 15000;
+
+/**
+ * @class PumpController
+ * @brief Hardware syringe pump controller wrapping the Cetoni QmixSDK.
+ *
+ * Implements PumpControllerInterface for real Cetoni Nemesys pump hardware.
+ * All QmixSDK calls (prefixed `LCB_*`, `LCP_*`) are serialised through an
+ * internal CommandQueue so that only one SDK call is in flight at a time,
+ * as required by the SDK's thread-safety model.
+ *
+ * ### Typical usage
+ * @code
+ *   auto pump = std::make_unique<PumpController>();
+ *   pump->setConfigPath("/path/to/cetoni/config");
+ *   pump->setPumpName("Nemesys_S_1");
+ *   pump->setSyringeParams(2.3, 60.0);  // 2.3 mm inner dia, 60 mm stroke
+ *   pump->connectDevice();               // async — emits stateChanged()
+ * @endcode
+ *
+ * ### Connection workflow (enqueued on CommandQueue)
+ * 1. `LCB_Open(config_path)` — open the CAN bus
+ * 2. `LCB_Start()` — start bus communication
+ * 3. `LCB_LookupPumpByName(pump_name)` — obtain device handle
+ * 4. `LCP_SetSyringeParam(handle, inner_dia, stroke)` — configure syringe
+ * 5. `LCP_SetVolumeUnit(handle, MICRO_LITRES)` — set volume unit
+ * 6. `LCP_SetFlowUnit(handle, MICRO_LITRES_PER_MIN)` — set flow unit
+ * 7. `LCP_Enable(handle, 1)` — enable the pump drive
+ * 8. Transition to DeviceState::kConnected
+ *
+ * ### Disconnection workflow
+ * 1. `LCP_StopPumping(handle)` — halt any active motion
+ * 2. `LCP_Enable(handle, 0)` — disable the drive
+ * 3. `LCB_Stop()` — stop bus communication
+ * 4. `LCB_Close()` — close the bus
+ * 5. Transition to DeviceState::kDisconnected
+ *
+ * @note Non-copyable, non-movable.
+ *
+ * @see PumpControllerInterface
+ * @see CommandQueue
+ * @see docs/protocols/cetoni_nemesys_spec.md
+ */
+class PumpController : public PumpControllerInterface {
+  Q_OBJECT
+
+ public:
+  /**
+   * @brief Construct a PumpController.
+   *
+   * The controller starts in DeviceState::kDisconnected.  Call
+   * setConfigPath(), setPumpName(), and optionally setSyringeParams()
+   * before connectDevice().
+   *
+   * @param parent Optional QObject parent for Qt ownership management.
+   */
+  explicit PumpController(QObject* parent = nullptr);
+
+  /**
+   * @brief Destructor — disconnects the device and shuts down the
+   *        command queue.
+   */
+  ~PumpController() override;
+
+  // Non-copyable, non-movable.
+  PumpController(const PumpController&) = delete;
+  PumpController& operator=(const PumpController&) = delete;
+  PumpController(PumpController&&) = delete;
+  PumpController& operator=(PumpController&&) = delete;
+
+  // ── Configuration (call before connectDevice) ───────────────
+
+  /**
+   * @brief Set the path to the Cetoni device configuration directory.
+   *
+   * This directory is created by the Cetoni Elements software and
+   * contains the bus and device description files needed by
+   * `LCB_Open()`.  Must be set before connectDevice().
+   *
+   * @param path Absolute path to the Cetoni config directory.
+   */
+  void setConfigPath(const QString& path);
+
+  /**
+   * @brief Return the currently configured Cetoni config directory.
+   *
+   * @return The config path, or an empty string if not set.
+   */
+  [[nodiscard]] QString configPath() const;
+
+  /**
+   * @brief Set the name used to look up the pump on the CAN bus.
+   *
+   * The name must match one of the pump devices defined in the Cetoni
+   * configuration (e.g. "Nemesys_S_1", "neMESYS_Low_Pressure_1").
+   * Used by `LCB_LookupPumpByName()` during connection.
+   *
+   * @param name Pump device name from the Cetoni configuration.
+   */
+  void setPumpName(const QString& name);
+
+  /**
+   * @brief Return the currently configured pump device name.
+   *
+   * @return The pump name, or an empty string if not set.
+   */
+  [[nodiscard]] QString pumpName() const;
+
+  /**
+   * @brief Configure the syringe geometry for the pump drive.
+   *
+   * These dimensions are passed to `LCP_SetSyringeParam()` during
+   * connection.  Correct syringe parameters are essential for accurate
+   * flow rate and volume calculations by the SDK.
+   *
+   * Common syringe dimensions (Hamilton):
+   * | Volume (µL) | Inner Diameter (mm) | Stroke (mm) |
+   * |-------------|---------------------|-------------|
+   * | 100         | 1.46                | 60.0        |
+   * | 250         | 2.30                | 60.0        |
+   * | 500         | 3.26                | 60.0        |
+   * | 1000        | 4.61                | 60.0        |
+   *
+   * @param inner_diameter_mm Syringe inner diameter in millimetres.
+   * @param stroke_mm         Syringe piston stroke length in millimetres.
+   */
+  void setSyringeParams(double inner_diameter_mm, double stroke_mm);
+
+  /**
+   * @brief Return the configured syringe inner diameter.
+   *
+   * @return Inner diameter in millimetres, or 0.0 if not set.
+   */
+  [[nodiscard]] double syringeInnerDiameter() const;
+
+  /**
+   * @brief Return the configured syringe stroke length.
+   *
+   * @return Stroke length in millimetres, or 0.0 if not set.
+   */
+  [[nodiscard]] double syringeStroke() const;
+
+  // ── DeviceInterface overrides ───────────────────────────────
+
+  /**
+   * @brief Open the CAN bus and initialise the pump.
+   *
+   * Transitions immediately to DeviceState::kConnecting, then enqueues
+   * the full connection sequence on the CommandQueue:
+   *
+   * 1. `LCB_Open(config_path_)`
+   * 2. `LCB_Start()`
+   * 3. `LCB_LookupPumpByName(pump_name_)` → store handle
+   * 4. `LCP_SetSyringeParam(handle, inner_dia_, stroke_)`
+   * 5. `LCP_SetVolumeUnit(handle, MICRO_LITRES)`
+   * 6. `LCP_SetFlowUnit(handle, MICRO_LITRES_PER_MIN)`
+   * 7. `LCP_Enable(handle, 1)`
+   * 8. Transition to kConnected and emit stateChanged()
+   *
+   * If any SDK call returns an error code, the sequence aborts,
+   * the state transitions to kError, and errorOccurred() is emitted
+   * with the SDK error description.
+   *
+   * @pre setConfigPath() and setPumpName() must have been called.
+   */
+  void connectDevice() override;
+
+  /**
+   * @brief Gracefully disconnect from the pump and close the CAN bus.
+   *
+   * Enqueues the shutdown sequence on the CommandQueue:
+   * 1. `LCP_StopPumping(handle)` — halt any active motion
+   * 2. `LCP_Enable(handle, 0)` — disable the pump drive
+   * 3. `LCB_Stop()` — stop bus communication
+   * 4. `LCB_Close()` — release bus resources
+   * 5. Transition to kDisconnected and emit stateChanged()
+   */
+  void disconnectDevice() override;
+
+  /**
+   * @brief Return the display name for this pump device.
+   *
+   * @return A string in the form "Pump Controller (<pump_name>)".
+   */
+  [[nodiscard]] QString deviceName() const override;
+
+  /**
+   * @brief Return the current connection state (thread-safe).
+   *
+   * @return The current DeviceState value, read under a mutex.
+   */
+  [[nodiscard]] DeviceState state() const override;
+
+  /**
+   * @brief Query whether the device is fully connected (thread-safe).
+   *
+   * @return @c true if the device state is DeviceState::kConnected.
+   */
+  [[nodiscard]] bool isConnected() const override;
+
+  // ── PumpControllerInterface overrides ───────────────────────
+
+  /**
+   * @brief Set the infusion flow rate.
+   *
+   * Validates the rate against the syringe-dependent maximum and
+   * caches it for the next startInfusion() call.  The QmixSDK does
+   * not have a "set flow rate" command; instead the rate is passed
+   * to `LCP_Dispense()` when infusion starts.
+   *
+   * Emits flowRateChanged() on success, or errorOccurred() if the
+   * device is not connected or the rate is out of range.
+   *
+   * @param uL_per_min Flow rate in microlitres per minute.
+   */
+  void setFlowRate(double uL_per_min) override;
+
+  /**
+   * @brief Return the current infusion flow rate (thread-safe).
+   *
+   * @return Flow rate in microlitres per minute.
+   */
+  [[nodiscard]] double flowRate() const override;
+
+  /**
+   * @brief Set the target infusion volume.
+   *
+   * Caches the target volume for the next startInfusion() call.
+   *
+   * @param uL Target volume in microlitres.
+   */
+  void setTargetVolume(double uL) override;
+
+  /**
+   * @brief Return the current target infusion volume (thread-safe).
+   *
+   * @return Target volume in microlitres.
+   */
+  [[nodiscard]] double targetVolume() const override;
+
+  /**
+   * @brief Start dispensing at the cached flow rate and target volume.
+   *
+   * Enqueues `LCP_Dispense(handle, target_volume_, flow_rate_)` on
+   * the CommandQueue.  On success, starts the position polling timer
+   * and emits infusionStarted().
+   *
+   * The polling timer fires every @c kPumpPollIntervalMs milliseconds,
+   * enqueuing a query that calls `LCP_GetFillLevel()` and
+   * `LCP_IsPumping()`.  Each poll emits positionChanged() with the
+   * current syringe fill level.  When `LCP_IsPumping()` returns false,
+   * the timer stops and infusionStopped() is emitted.
+   *
+   * @pre Device must be connected.  Flow rate and target volume must
+   *      have been set.
+   */
+  void startInfusion() override;
+
+  /**
+   * @brief Immediately stop the pump and halt infusion.
+   *
+   * Enqueues `LCP_StopPumping(handle)` on the CommandQueue, stops
+   * the polling timer, and emits infusionStopped().
+   */
+  void stopInfusion() override;
+
+  /**
+   * @brief Aspirate to refill the syringe to maximum capacity.
+   *
+   * Enqueues `LCP_Aspirate(handle, max_volume, refill_rate)` on the
+   * CommandQueue.  Starts the position polling timer to track refill
+   * progress.  The refill completes automatically when the syringe
+   * fill level reaches maximum.
+   *
+   * The refill flow rate is determined by the syringe size and is
+   * typically set to a moderate rate to avoid damaging the syringe.
+   */
+  void refill() override;
+
+  /**
+   * @brief Return the current syringe fill level (thread-safe).
+   *
+   * The fill level is updated by the polling timer during infusion
+   * or refill via `LCP_GetFillLevel()`.
+   *
+   * @return Syringe fill level in microlitres.
+   */
+  [[nodiscard]] double currentPosition() const override;
+
+  /**
+   * @brief Query whether the pump is actively dispensing (thread-safe).
+   *
+   * Updated by the polling timer via `LCP_IsPumping()`.
+   *
+   * @return @c true if the pump is currently infusing.
+   */
+  [[nodiscard]] bool isInfusing() const override;
+
+ private:
+  /**
+   * @brief Thread-safe setter for the device state.
+   *
+   * Updates state_ under mutex_ and emits stateChanged().
+   *
+   * @param new_state The new device state.
+   */
+  void setState(DeviceState new_state);
+
+  /**
+   * @brief Handle one position polling timer tick.
+   *
+   * Enqueues a query on the CommandQueue that calls
+   * `LCP_GetFillLevel()` and `LCP_IsPumping()`.  If the pump has
+   * stopped, the timer is stopped and infusionStopped() is emitted.
+   * Otherwise positionChanged() is emitted with the updated fill level.
+   */
+  void onPollTick();
+
+  /**
+   * @brief Start the position polling timer.
+   *
+   * Connects the timer to onPollTick() and starts it with
+   * @c kPumpPollIntervalMs interval.
+   */
+  void startPolling();
+
+  /**
+   * @brief Stop the position polling timer.
+   */
+  void stopPolling();
+
+  /// Serialises all QmixSDK calls onto a single worker thread.
+  std::unique_ptr<CommandQueue> command_queue_;
+
+  /// SDK device handle for the pump, obtained from LCB_LookupPumpByName().
+  QmixDeviceHandle pump_handle_{kInvalidQmixHandle};
+
+  /// Timer that polls fill level / pumping state during infusion/refill.
+  QTimer poll_timer_;
+
+  mutable QMutex mutex_;  ///< Guards all cached state below.
+
+  // ── Cached state (read/written under mutex_) ─────────────────
+
+  DeviceState state_{DeviceState::kDisconnected};  ///< Connection state.
+  double flow_rate_{0.0};         ///< Cached flow rate in µL/min.
+  double target_volume_{0.0};     ///< Cached target volume in µL.
+  double position_{0.0};          ///< Cached syringe fill level in µL.
+  bool is_infusing_{false};       ///< Whether the pump is actively dispensing.
+
+  // ── Configuration (set before connectDevice) ──────────────────
+
+  QString config_path_;           ///< Cetoni device configuration directory.
+  QString pump_name_;             ///< Pump device name for bus lookup.
+  double syringe_inner_dia_{0.0}; ///< Syringe inner diameter in mm.
+  double syringe_stroke_{0.0};    ///< Syringe piston stroke in mm.
+};
+
+}  // namespace mwa::hardware

--- a/src/hardware/signal_generator/signal_generator_controller.h
+++ b/src/hardware/signal_generator/signal_generator_controller.h
@@ -1,0 +1,570 @@
+/**
+ * @file signal_generator_controller.h
+ * @brief Hardware signal generator driver skeleton for SCPI-based instruments.
+ * @author onuronarici
+ * @date 2026-04-04
+ *
+ * Declares the SignalGeneratorController class, which drives SCPI-based
+ * signal/waveform generators (Rigol DG1000Z, Keysight 33500B, Tektronix
+ * AFG1022 and compatible models) over a serial or USB-TMC transport.  All
+ * SCPI I/O is serialised through a CommandQueue running on a dedicated
+ * worker thread, and the actual command strings are selected via a
+ * vendor-configurable ScpiCommandTable.
+ *
+ * This is a **header-only skeleton** — the .cpp implementation will be
+ * written when physical hardware becomes available.  The header is fully
+ * documented so that the implementation can be written directly from the
+ * Doxygen comments and the protocol specification in
+ * `docs/protocols/signal_generator_scpi_spec.md`.
+ *
+ * @note This header is not currently compiled via CMake.  When the .cpp
+ *       implementation is written, both files will be added to the
+ *       `if(TARGET Qt6::SerialPort)` conditional block in
+ *       `src/hardware/CMakeLists.txt`.
+ *
+ * @note The GUI always works against SignalGeneratorControllerInterface*.
+ *       On platforms without hardware, MockSignalGeneratorController is
+ *       used instead.
+ *
+ * @see SignalGeneratorControllerInterface
+ * @see ScpiClient
+ * @see CommandQueue
+ * @see MockSignalGeneratorController
+ * @see docs/protocols/signal_generator_scpi_spec.md
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <QMutex>
+#include <QString>
+
+#include <cstdint>
+#include <memory>
+
+#include "hardware/command_queue.h"
+#include "hardware/signal_generator/signal_generator_controller_interface.h"
+
+namespace mwa::hardware {
+
+// Forward declarations — full headers included in the .cpp only.
+class ScpiClient;
+class ScpiTransport;
+
+/// Default SCPI command timeout in milliseconds.
+inline constexpr int kSigGenCommandTimeoutMs = 5000;
+
+/// Timeout for the multi-step connect sequence in milliseconds.
+inline constexpr int kSigGenConnectTimeoutMs = 15000;
+
+/// Default serial baud rate for signal generators (bits per second).
+inline constexpr qint32 kSigGenDefaultBaudRate = 9600;
+
+/// Default SCPI source channel number (1-based).
+inline constexpr int kSigGenDefaultChannel = 1;
+
+/**
+ * @enum SignalGeneratorVendor
+ * @brief Identifies the signal generator vendor for command-set selection.
+ *
+ * Different vendors use slightly different SCPI command trees for
+ * triangle waveforms, sweep control, and output-state query responses.
+ * The vendor is either set explicitly via setVendor() or auto-detected
+ * from the `*IDN?` response during connectDevice().
+ *
+ * @see ScpiCommandTable
+ * @see SignalGeneratorController::detectVendorFromIdn()
+ */
+enum class SignalGeneratorVendor {
+  kGeneric,    ///< Generic SCPI (common-subset commands only).
+  kRigol,      ///< Rigol DG1000Z / DG800 series.
+  kKeysight,   ///< Keysight 33500B / 33600A (formerly Agilent) series.
+  kTektronix   ///< Tektronix AFG1022 / AFG3000C series.
+};
+
+/**
+ * @struct ScpiCommandTable
+ * @brief Vendor-specific SCPI command strings for signal generators.
+ *
+ * Most SCPI commands are identical across Rigol, Keysight, and Tektronix.
+ * This table captures the areas that differ between vendors:
+ * - Triangle waveform: Keysight uses `FUNC TRI`; Rigol and Tektronix
+ *   use `FUNC RAMP` with 50 % symmetry
+ * - Sweep enable/disable: Rigol/Tek use `SWE:STAT ON/OFF`; Keysight
+ *   uses `FREQ:MODE SWE/CW`
+ * - Output query response format: Rigol returns `ON`/`OFF`; Keysight
+ *   and Tektronix return `1`/`0`
+ *
+ * Command strings use Qt `QString::arg()` placeholders: `%1` for the
+ * channel number and `%2` for the parameter value.
+ *
+ * @see scpiCommandsForVendor()
+ * @see docs/protocols/signal_generator_scpi_spec.md Section 4
+ */
+struct ScpiCommandTable {
+  QString set_frequency;         ///< e.g. ":SOUR%1:FREQ %2"
+  QString query_frequency;       ///< e.g. ":SOUR%1:FREQ?"
+  QString set_amplitude;         ///< e.g. ":SOUR%1:VOLT %2"
+  QString query_amplitude;       ///< e.g. ":SOUR%1:VOLT?"
+  QString set_waveform_sine;     ///< e.g. ":SOUR%1:FUNC SIN"
+  QString set_waveform_square;   ///< e.g. ":SOUR%1:FUNC SQU"
+  QString set_waveform_triangle; ///< e.g. ":SOUR%1:FUNC TRI" (Keysight) or ":SOUR%1:FUNC RAMP" (Rigol/Tek)
+  QString set_triangle_symmetry; ///< e.g. ":SOUR%1:FUNC:RAMP:SYMM 50" (Rigol/Tek only; empty for Keysight)
+  QString query_waveform;        ///< e.g. ":SOUR%1:FUNC?"
+  QString set_output_on;         ///< e.g. ":OUTP%1 ON"
+  QString set_output_off;        ///< e.g. ":OUTP%1 OFF"
+  QString query_output;          ///< e.g. ":OUTP%1?"
+  QString sweep_enable;          ///< e.g. ":SOUR%1:SWE:STAT ON" (Rigol/Tek) or "SOUR%1:FREQ:MODE SWE" (Keysight)
+  QString sweep_disable;         ///< e.g. ":SOUR%1:SWE:STAT OFF" (Rigol/Tek) or "SOUR%1:FREQ:MODE CW" (Keysight)
+  QString set_sweep_start;       ///< e.g. ":SOUR%1:FREQ:STAR %2"
+  QString set_sweep_stop;        ///< e.g. ":SOUR%1:FREQ:STOP %2"
+  QString set_sweep_spacing;     ///< e.g. ":SOUR%1:SWE:SPAC LIN"
+  QString set_sweep_time;        ///< e.g. ":SOUR%1:SWE:TIME %2"
+  bool output_response_numeric;  ///< @c true if OUTP? returns "1"/"0" (Keysight/Tek); @c false if "ON"/"OFF" (Rigol).
+};
+
+/**
+ * @brief Return the SCPI command table for the given vendor.
+ *
+ * Returns a pre-populated ScpiCommandTable with the command strings
+ * appropriate for @p vendor.  For kGeneric, the Rigol command set is
+ * used as it is the most widely compatible.
+ *
+ * @param vendor The target instrument vendor.
+ * @return A fully populated ScpiCommandTable.
+ *
+ * @note Defined in signal_generator_controller.cpp (not yet implemented).
+ */
+[[nodiscard]] ScpiCommandTable scpiCommandsForVendor(
+    SignalGeneratorVendor vendor);
+
+/**
+ * @class SignalGeneratorController
+ * @brief Hardware signal generator controller using SCPI over serial.
+ *
+ * Implements SignalGeneratorControllerInterface for real SCPI-based signal
+ * generators.  All SCPI commands are sent through a ScpiClient instance
+ * and serialised via an internal CommandQueue so that only one command
+ * is in flight at a time.
+ *
+ * The driver supports three vendor families — Rigol, Keysight, and
+ * Tektronix — with automatic vendor detection from the `*IDN?` identity
+ * string.  Vendor-specific command differences (triangle waveform, sweep
+ * control, output-state parsing) are captured in a ScpiCommandTable that
+ * is selected at connect time.
+ *
+ * ### Typical usage
+ * @code
+ *   auto sig_gen = std::make_unique<SignalGeneratorController>();
+ *   sig_gen->setPortName("/dev/ttyUSB0");
+ *   sig_gen->setBaudRate(115200);
+ *   sig_gen->connectDevice();  // async — auto-detects vendor via *IDN?
+ * @endcode
+ *
+ * ### Connection workflow (enqueued on CommandQueue)
+ * 1. Create SerialTransport with port_name_ and baud_rate_
+ * 2. Create ScpiClient wrapping the transport
+ * 3. `scpi_client_->open(port_name_)` — open the serial port
+ * 4. `scpi_client_->identify()` — send `*IDN?`, receive identity string
+ * 5. Auto-detect vendor from identity (or use pre-set vendor)
+ * 6. Load vendor-specific ScpiCommandTable
+ * 7. `scpi_client_->reset()` — send `*RST` to reset instrument state
+ * 8. `scpi_client_->command("*CLS")` — clear error queue
+ * 9. Send `:OUTPn OFF` — ensure output disabled (safety)
+ * 10. Query current frequency, amplitude, waveform, output state
+ * 11. Transition to DeviceState::kConnected
+ *
+ * ### Disconnection workflow
+ * 1. Send `:OUTPn OFF` — disable output (safety)
+ * 2. `scpi_client_->close()` — close serial transport
+ * 3. Transition to DeviceState::kDisconnected
+ *
+ * @note Non-copyable, non-movable.
+ *
+ * @see SignalGeneratorControllerInterface
+ * @see ScpiClient
+ * @see CommandQueue
+ * @see ScpiCommandTable
+ * @see docs/protocols/signal_generator_scpi_spec.md
+ */
+class SignalGeneratorController
+    : public SignalGeneratorControllerInterface {
+  Q_OBJECT
+
+ public:
+  /**
+   * @brief Construct a SignalGeneratorController.
+   *
+   * The controller starts in DeviceState::kDisconnected.  Call
+   * setPortName() and optionally setBaudRate() / setVendor() /
+   * setChannel() before connectDevice().
+   *
+   * @param parent Optional QObject parent for Qt ownership management.
+   */
+  explicit SignalGeneratorController(QObject* parent = nullptr);
+
+  /**
+   * @brief Destructor — disconnects the device and shuts down the
+   *        command queue.
+   */
+  ~SignalGeneratorController() override;
+
+  // Non-copyable, non-movable.
+  SignalGeneratorController(const SignalGeneratorController&) = delete;
+  SignalGeneratorController& operator=(
+      const SignalGeneratorController&) = delete;
+  SignalGeneratorController(SignalGeneratorController&&) = delete;
+  SignalGeneratorController& operator=(
+      SignalGeneratorController&&) = delete;
+
+  // ── Configuration (call before connectDevice) ───────────────
+
+  /**
+   * @brief Set the serial port name before connecting.
+   *
+   * Must be called before connectDevice().  Has no effect while the
+   * device is connected.
+   *
+   * @param name Platform-specific port identifier
+   *             (e.g. "/dev/ttyUSB0", "COM3").
+   */
+  void setPortName(const QString& name);
+
+  /**
+   * @brief Return the currently configured serial port name.
+   *
+   * @return The port name string.
+   */
+  [[nodiscard]] QString portName() const;
+
+  /**
+   * @brief Set the serial baud rate before connecting.
+   *
+   * Must be called before connectDevice().  The default is
+   * @c kSigGenDefaultBaudRate (9600).
+   *
+   * @param baud Baud rate value (e.g. 9600, 115200).
+   */
+  void setBaudRate(qint32 baud);
+
+  /**
+   * @brief Return the currently configured baud rate.
+   *
+   * @return The baud rate in bits per second.
+   */
+  [[nodiscard]] qint32 baudRate() const;
+
+  /**
+   * @brief Set the instrument vendor explicitly.
+   *
+   * Overrides automatic vendor detection from `*IDN?`.  If not called,
+   * the vendor is auto-detected during connectDevice().  Can be called
+   * before connect to force a specific command set, or after connect
+   * to override the auto-detected vendor.
+   *
+   * @param vendor The target instrument vendor.
+   *
+   * @see SignalGeneratorVendor
+   */
+  void setVendor(SignalGeneratorVendor vendor);
+
+  /**
+   * @brief Return the current instrument vendor.
+   *
+   * Before connectDevice() this returns the explicitly set vendor (or
+   * kGeneric if not set).  After connect it returns the auto-detected
+   * or explicitly overridden vendor.
+   *
+   * @return The current SignalGeneratorVendor value.
+   */
+  [[nodiscard]] SignalGeneratorVendor vendor() const;
+
+  /**
+   * @brief Set the SCPI source channel number.
+   *
+   * Multi-channel instruments (e.g. Rigol DG1062Z, Keysight 33512B)
+   * address outputs as `SOURce1:`, `SOURce2:`, etc.  The default is
+   * @c kSigGenDefaultChannel (1).
+   *
+   * @param channel 1-based channel number.
+   */
+  void setChannel(int channel);
+
+  /**
+   * @brief Return the currently configured SCPI channel number.
+   *
+   * @return The 1-based channel number.
+   */
+  [[nodiscard]] int channel() const;
+
+  // ── DeviceInterface overrides ───────────────────────────────
+
+  /**
+   * @brief Open the serial port and initialise the instrument.
+   *
+   * Transitions immediately to DeviceState::kConnecting, then enqueues
+   * the full connection sequence on the CommandQueue:
+   *
+   * 1. Create a SerialTransport with port_name_ and baud_rate_
+   * 2. Construct a ScpiClient wrapping the transport
+   * 3. `scpi_client_->open(port_name_)` — open the serial port
+   * 4. `scpi_client_->identify()` — send `*IDN?`
+   * 5. Auto-detect vendor from the IDN response string
+   *    (or use the vendor set via setVendor())
+   * 6. Load the vendor-specific ScpiCommandTable via
+   *    scpiCommandsForVendor()
+   * 7. `scpi_client_->reset()` — send `*RST`
+   * 8. `scpi_client_->command("*CLS")` — clear status/error queue
+   * 9. Send `:OUTPn OFF` — ensure output disabled for safety
+   * 10. Query current frequency (`SOURce:FREQ?`), amplitude
+   *     (`SOURce:VOLT?`), waveform (`SOURce:FUNC?`), and output
+   *     state (`OUTPn?`) — cache results
+   * 11. Transition to kConnected and emit stateChanged()
+   *
+   * If any step fails, the state transitions to kError and
+   * errorOccurred() is emitted with a descriptive message.
+   *
+   * @pre setPortName() must have been called.
+   */
+  void connectDevice() override;
+
+  /**
+   * @brief Disable output and close the serial connection.
+   *
+   * Enqueues the shutdown sequence on the CommandQueue:
+   * 1. Send `:OUTPn OFF` — disable signal output for safety
+   * 2. `scpi_client_->close()` — close the serial transport
+   * 3. Transition to kDisconnected and emit stateChanged()
+   */
+  void disconnectDevice() override;
+
+  /**
+   * @brief Return the display name for this device.
+   *
+   * @return A string in the form "Signal Generator (<port_name>)".
+   */
+  [[nodiscard]] QString deviceName() const override;
+
+  /**
+   * @brief Return the current connection state (thread-safe).
+   *
+   * @return The current DeviceState value, read under a mutex.
+   */
+  [[nodiscard]] DeviceState state() const override;
+
+  /**
+   * @brief Query whether the device is fully connected (thread-safe).
+   *
+   * @return @c true if the device state is DeviceState::kConnected.
+   */
+  [[nodiscard]] bool isConnected() const override;
+
+  // ── SignalGeneratorControllerInterface overrides ─────────────
+
+  /**
+   * @brief Set the output frequency via SCPI.
+   *
+   * Enqueues on the CommandQueue:
+   * 1. Send the `set_frequency` command from the vendor command table
+   *    (e.g. `:SOUR1:FREQ 1000000` for 1 MHz)
+   * 2. Send `SYST:ERR?` to check for instrument errors
+   * 3. Query back with `query_frequency` (e.g. `:SOUR1:FREQ?`)
+   * 4. Parse the response, cache the value, emit frequencyChanged()
+   *
+   * On error emits errorOccurred() without changing the cached value.
+   *
+   * @param hz Output frequency in hertz.
+   *
+   * @pre Device must be connected.
+   */
+  void setFrequency(double hz) override;
+
+  /**
+   * @brief Return the cached output frequency (thread-safe).
+   *
+   * @return Output frequency in hertz.
+   */
+  [[nodiscard]] double frequency() const override;
+
+  /**
+   * @brief Set the output amplitude via SCPI.
+   *
+   * Enqueues on the CommandQueue:
+   * 1. Send `set_amplitude` (e.g. `:SOUR1:VOLT 2.5`)
+   * 2. Check `SYST:ERR?`
+   * 3. Query back with `query_amplitude` (e.g. `:SOUR1:VOLT?`)
+   * 4. Parse, cache, emit amplitudeChanged()
+   *
+   * @param volts Peak amplitude in volts (Vpp).
+   *
+   * @pre Device must be connected.
+   */
+  void setAmplitude(double volts) override;
+
+  /**
+   * @brief Return the cached output amplitude (thread-safe).
+   *
+   * @return Peak amplitude in volts (Vpp).
+   */
+  [[nodiscard]] double amplitude() const override;
+
+  /**
+   * @brief Set the output waveform shape via SCPI.
+   *
+   * Enqueues on the CommandQueue:
+   * - **kSine:** send `set_waveform_sine` (e.g. `:SOUR1:FUNC SIN`)
+   * - **kSquare:** send `set_waveform_square` (e.g. `:SOUR1:FUNC SQU`)
+   * - **kTriangle:**
+   *   - **Keysight:** send `set_waveform_triangle` (`:SOUR1:FUNC TRI`)
+   *   - **Rigol / Tektronix:** send `set_waveform_triangle`
+   *     (`:SOUR1:FUNC RAMP`) followed by `set_triangle_symmetry`
+   *     (`:SOUR1:FUNC:RAMP:SYMM 50`) to produce a symmetric triangle
+   *
+   * Then queries back with `query_waveform`, parses the response via
+   * parseWaveformResponse(), caches the value, and emits
+   * waveformChanged().
+   *
+   * @param waveform The desired Waveform value.
+   *
+   * @pre Device must be connected.
+   */
+  void setWaveform(Waveform waveform) override;
+
+  /**
+   * @brief Return the cached output waveform shape (thread-safe).
+   *
+   * @return The current Waveform value.
+   */
+  [[nodiscard]] Waveform waveform() const override;
+
+  /**
+   * @brief Enable or disable the signal output via SCPI.
+   *
+   * Enqueues on the CommandQueue:
+   * 1. Send `set_output_on` or `set_output_off` depending on
+   *    @p enabled (e.g. `:OUTP1 ON` or `:OUTP1 OFF`)
+   * 2. Query back with `query_output` (e.g. `:OUTP1?`)
+   * 3. Parse response via parseOutputResponse() — handles both
+   *    numeric (`1`/`0`) and text (`ON`/`OFF`) formats
+   * 4. Cache the value, emit outputStateChanged()
+   *
+   * @param enabled @c true to enable the output, @c false to disable.
+   *
+   * @pre Device must be connected.
+   */
+  void setOutputEnabled(bool enabled) override;
+
+  /**
+   * @brief Return the cached output enable state (thread-safe).
+   *
+   * @return @c true if the output is currently enabled.
+   */
+  [[nodiscard]] bool isOutputEnabled() const override;
+
+  /**
+   * @brief Configure a frequency sweep via SCPI.
+   *
+   * Enqueues the sweep configuration sequence on the CommandQueue:
+   * 1. Send `sweep_disable` — disable sweep while reconfiguring
+   * 2. Send `set_sweep_start` with @p start_hz
+   * 3. Send `set_sweep_stop` with @p stop_hz
+   * 4. Send `set_sweep_spacing` (always linear)
+   * 5. Compute sweep time from the step size:
+   *    `time_s = (stop_hz - start_hz) / step_hz * dwell_per_step`
+   * 6. Send `set_sweep_time` with the computed time
+   * 7. Send `sweep_enable` — activate the sweep
+   *
+   * No query-back is performed for sweep parameters.
+   *
+   * @param start_hz Start frequency of the sweep in hertz.
+   * @param stop_hz  Stop frequency of the sweep in hertz.
+   * @param step_hz  Frequency step size in hertz.  Used to compute the
+   *                 total sweep time (smaller steps → longer sweep).
+   *
+   * @pre Device must be connected.
+   */
+  void configureSweep(
+      double start_hz, double stop_hz, double step_hz) override;
+
+ private:
+  /**
+   * @brief Thread-safe setter for the device state.
+   *
+   * Updates state_ under mutex_ and emits stateChanged().
+   *
+   * @param new_state The new device state.
+   */
+  void setState(DeviceState new_state);
+
+  /**
+   * @brief Auto-detect the instrument vendor from an `*IDN?` response.
+   *
+   * Parses the identity string (format:
+   * `<Manufacturer>,<Model>,<Serial>,<Firmware>`) and checks the
+   * manufacturer field for:
+   * - "RIGOL" → kRigol
+   * - "Keysight" or "Agilent" → kKeysight
+   * - "TEKTRONIX" → kTektronix
+   *
+   * Falls back to kGeneric if no known vendor is detected.
+   *
+   * @param idn_response The raw `*IDN?` response string.
+   * @return The detected SignalGeneratorVendor.
+   */
+  [[nodiscard]] SignalGeneratorVendor detectVendorFromIdn(
+      const QString& idn_response) const;
+
+  /**
+   * @brief Parse a `SOURce:FUNC?` response into a Waveform enum.
+   *
+   * Maps common response strings to Waveform values:
+   * - "SIN" or "SINUSOID" → kSine
+   * - "SQU" or "SQUARE" → kSquare
+   * - "TRI", "TRIANGLE", "RAMP" → kTriangle
+   *
+   * @param response The trimmed SCPI response string.
+   * @return The corresponding Waveform value, or kSine as fallback.
+   */
+  [[nodiscard]] Waveform parseWaveformResponse(
+      const QString& response) const;
+
+  /**
+   * @brief Parse an `OUTPut?` response into a boolean.
+   *
+   * Handles both response formats:
+   * - Numeric: "1" → true, "0" → false (Keysight, Tektronix)
+   * - Text: "ON" → true, "OFF" → false (Rigol)
+   *
+   * @param response The trimmed SCPI response string.
+   * @return @c true if the output is enabled.
+   */
+  [[nodiscard]] bool parseOutputResponse(
+      const QString& response) const;
+
+  /// Serialises all SCPI commands onto a single worker thread.
+  std::unique_ptr<CommandQueue> command_queue_;
+
+  /// SCPI command/query interface.  Created during connectDevice().
+  std::unique_ptr<ScpiClient> scpi_client_;
+
+  mutable QMutex mutex_;  ///< Guards all cached state below.
+
+  // ── Cached state (read/written under mutex_) ─────────────────
+
+  DeviceState state_{DeviceState::kDisconnected};  ///< Connection state.
+  double frequency_{0.0};                          ///< Cached frequency in Hz.
+  double amplitude_{0.0};                          ///< Cached amplitude in Vpp.
+  Waveform waveform_{Waveform::kSine};             ///< Cached waveform shape.
+  bool output_enabled_{false};                     ///< Cached output state.
+
+  // ── Configuration (set before connectDevice) ──────────────────
+
+  QString port_name_;           ///< Serial port name (e.g. "/dev/ttyUSB0").
+  qint32 baud_rate_{kSigGenDefaultBaudRate};  ///< Serial baud rate (bps).
+  SignalGeneratorVendor vendor_{SignalGeneratorVendor::kGeneric};  ///< Instrument vendor.
+  int channel_{kSigGenDefaultChannel};  ///< SCPI source channel (1-based).
+  ScpiCommandTable commands_;   ///< Active vendor-specific command table.
+};
+
+}  // namespace mwa::hardware


### PR DESCRIPTION
## Summary
- **MWA-08-C: PumpController skeleton** (`pump_controller.h`): Header-only driver wrapping the Cetoni QmixSDK C API for Nemesys syringe pumps. Full Doxygen with connection/disconnection workflows, syringe configuration, and infusion/refill/polling design.
- **FindQmixSDK.cmake**: CMake find module for the Cetoni SDK (Windows/Linux search paths, macOS early-out, imported target).
- **MWA-09-C: SignalGeneratorController skeleton** (`signal_generator_controller.h`): Header-only driver wrapping SCPI commands for Rigol, Keysight, and Tektronix signal generators via ScpiClient. Features a vendor-configurable ScpiCommandTable, auto-detection from `*IDN?`, and documented SCPI workflows for all interface methods.
- **CMake integration**: Module path configured, QmixSDK conditional build for pump driver.

## Handoff Summary
**What to test:**
- CI green on both macOS and Windows (QmixSDK won't be found — expected; signal gen header not in build — expected)
- Review `pump_controller.h` Doxygen against `docs/protocols/cetoni_nemesys_spec.md`
- Review `signal_generator_controller.h` Doxygen against `docs/protocols/signal_generator_scpi_spec.md`
- Verify `FindQmixSDK.cmake` search paths and imported target creation

**What to focus on:**
- **Pump**: API design matches PumpControllerInterface? Connection workflow matches Cetoni SDK sequence?
- **Signal Generator**: ScpiCommandTable design — does the vendor abstraction cover all command differences? Triangle waveform vendor branching? Sweep configuration?
- **CMake**: Clean pattern for optional SDK dependencies?

## Test plan
- [x] All 25 tests pass locally on macOS
- [x] CI green on macOS (both commits)
- [x] CI green on Windows (both commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)