### PR TITLE
Fix driver skeleton review findings

### DIFF
--- a/src/hardware/CMakeLists.txt
+++ b/src/hardware/CMakeLists.txt
@@ -68,7 +68,6 @@ endif()
 if(QmixSDK_FOUND)
   target_sources(MwaHardware PRIVATE
     pump/pump_controller.h
-    pump/pump_controller.cpp
   )
   target_link_libraries(MwaHardware PRIVATE QmixSDK::QmixSDK)
   target_compile_definitions(MwaHardware PRIVATE MWA_HAS_QMIXSDK)

--- a/src/hardware/pump/pump_controller.h
+++ b/src/hardware/pump/pump_controller.h
@@ -138,6 +138,7 @@ class PumpController : public PumpControllerInterface {
    * contains the bus and device description files needed by
    * `LCB_Open()`.  Must be set before connectDevice().
    *
+   * @warning Not thread-safe — call only while disconnected.
    * @param path Absolute path to the Cetoni config directory.
    */
   void setConfigPath(const QString& path);
@@ -156,6 +157,7 @@ class PumpController : public PumpControllerInterface {
    * configuration (e.g. "Nemesys_S_1", "neMESYS_Low_Pressure_1").
    * Used by `LCB_LookupPumpByName()` during connection.
    *
+   * @warning Not thread-safe — call only while disconnected.
    * @param name Pump device name from the Cetoni configuration.
    */
   void setPumpName(const QString& name);
@@ -173,6 +175,8 @@ class PumpController : public PumpControllerInterface {
    * These dimensions are passed to `LCP_SetSyringeParam()` during
    * connection.  Correct syringe parameters are essential for accurate
    * flow rate and volume calculations by the SDK.
+   *
+   * @warning Not thread-safe — call only while disconnected.
    *
    * Common syringe dimensions (Hamilton):
    * | Volume (µL) | Inner Diameter (mm) | Stroke (mm) |

--- a/src/hardware/signal_generator/signal_generator_controller.h
+++ b/src/hardware/signal_generator/signal_generator_controller.h
@@ -226,6 +226,7 @@ class SignalGeneratorController
    * Must be called before connectDevice().  Has no effect while the
    * device is connected.
    *
+   * @warning Not thread-safe — call only while disconnected.
    * @param name Platform-specific port identifier
    *             (e.g. "/dev/ttyUSB0", "COM3").
    */
@@ -244,6 +245,7 @@ class SignalGeneratorController
    * Must be called before connectDevice().  The default is
    * @c kSigGenDefaultBaudRate (9600).
    *
+   * @warning Not thread-safe — call only while disconnected.
    * @param baud Baud rate value (e.g. 9600, 115200).
    */
   void setBaudRate(qint32 baud);
@@ -263,6 +265,7 @@ class SignalGeneratorController
    * before connect to force a specific command set, or after connect
    * to override the auto-detected vendor.
    *
+   * @warning Not thread-safe — call only while disconnected.
    * @param vendor The target instrument vendor.
    *
    * @see SignalGeneratorVendor
@@ -287,6 +290,7 @@ class SignalGeneratorController
    * address outputs as `SOURce1:`, `SOURce2:`, etc.  The default is
    * @c kSigGenDefaultChannel (1).
    *
+   * @warning Not thread-safe — call only while disconnected.
    * @param channel 1-based channel number.
    */
   void setChannel(int channel);


### PR DESCRIPTION
## Summary
- Remove non-existent `pump_controller.cpp` from CMake `target_sources` (would cause build failure if QmixSDK is installed)
- Add `@warning Not thread-safe — call only while disconnected.` to all configuration setters in `PumpController` and `SignalGeneratorController` headers

## Handoff Summary
**What to test:**
- CI green on both platforms
- Verify the three changed files look correct in the diff

**What to focus on:**
- CMake still correctly guards the pump driver behind `if(QmixSDK_FOUND)`
- Doxygen `@warning` tags are placed before `@param` in all seven setters

## Test plan
- [x] All 25 tests pass locally on macOS
- [x] Build succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)