### PR TITLE
MWA-12-A: Experiment session data model

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(core)
 add_subdirectory(hardware)
 add_subdirectory(gui)
+add_subdirectory(analysis)
 add_subdirectory(app)
 
 add_executable(MWA main.cpp)

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(MwaAnalysis STATIC
+  experiment_session.h
+  experiment_session.cpp
+)
+
+target_include_directories(MwaAnalysis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+target_link_libraries(MwaAnalysis PUBLIC Qt6::Core Qt6::Gui)

--- a/src/analysis/experiment_session.cpp
+++ b/src/analysis/experiment_session.cpp
@@ -1,0 +1,204 @@
+/**
+ * @file experiment_session.cpp
+ * @brief ExperimentSession implementation.
+ * @author MWA Team
+ * @date 2026-04-05
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#include "analysis/experiment_session.h"
+
+#include <QtDebug>
+
+namespace mwa::analysis {
+
+ExperimentSession::ExperimentSession(QObject* parent) : QObject(parent) {}
+
+// ---------------------------------------------------------------------------
+// Session lifecycle
+// ---------------------------------------------------------------------------
+
+void ExperimentSession::start(const QString& name,
+                               const QString& description) {
+  if (is_active_) {
+    end();
+  }
+
+  clear();
+  name_        = name;
+  description_ = description;
+  start_time_  = QDateTime::currentDateTime();
+  is_active_   = true;
+
+  emit sessionStarted(name_);
+}
+
+void ExperimentSession::end() {
+  if (!is_active_) {
+    return;
+  }
+
+  end_time_  = QDateTime::currentDateTime();
+  is_active_ = false;
+
+  emit sessionEnded();
+}
+
+bool ExperimentSession::isActive() const { return is_active_; }
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+QString   ExperimentSession::name()        const { return name_; }
+QString   ExperimentSession::description() const { return description_; }
+QDateTime ExperimentSession::startTime()   const { return start_time_; }
+QDateTime ExperimentSession::endTime()     const { return end_time_; }
+
+// ---------------------------------------------------------------------------
+// Data ingestion
+// ---------------------------------------------------------------------------
+
+void ExperimentSession::addCameraFrame(const QImage& image) {
+  if (!is_active_) {
+    return;
+  }
+
+  camera_frames_.append(
+      CameraFrame{image, QDateTime::currentDateTime()});
+  emit cameraFrameAdded(camera_frames_.size());
+}
+
+void ExperimentSession::addVnaMeasurement(const QVector<double>& frequencies,
+                                           const QVector<double>& magnitudes,
+                                           double start_frequency,
+                                           double stop_frequency,
+                                           int num_points) {
+  if (!is_active_) {
+    return;
+  }
+
+  if (frequencies.size() != magnitudes.size()) {
+    qWarning() << "ExperimentSession::addVnaMeasurement: frequencies and"
+                  " magnitudes have different lengths — measurement discarded";
+    return;
+  }
+
+  VnaMeasurement m;
+  m.start_frequency = start_frequency;
+  m.stop_frequency  = stop_frequency;
+  m.num_points      = num_points;
+  m.frequencies     = frequencies;
+  m.magnitudes      = magnitudes;
+  m.timestamp       = QDateTime::currentDateTime();
+
+  vna_measurements_.append(std::move(m));
+  emit vnaMeasurementAdded(vna_measurements_.size());
+}
+
+void ExperimentSession::addPumpSample(double position, double flow_rate) {
+  if (!is_active_) {
+    return;
+  }
+
+  pump_samples_.append(
+      PumpSample{position, flow_rate, QDateTime::currentDateTime()});
+  emit pumpSampleAdded(pump_samples_.size());
+}
+
+void ExperimentSession::addLedSample(bool power_on, double intensity) {
+  if (!is_active_) {
+    return;
+  }
+
+  led_samples_.append(
+      LedSample{power_on, intensity, QDateTime::currentDateTime()});
+  emit ledSampleAdded(led_samples_.size());
+}
+
+void ExperimentSession::addSigGenSample(double frequency, double amplitude) {
+  if (!is_active_) {
+    return;
+  }
+
+  sig_gen_samples_.append(
+      SigGenSample{frequency, amplitude, QDateTime::currentDateTime()});
+  emit sigGenSampleAdded(sig_gen_samples_.size());
+}
+
+void ExperimentSession::addStageSample(double x, double y, double z) {
+  if (!is_active_) {
+    return;
+  }
+
+  stage_samples_.append(
+      StageSample{x, y, z, QDateTime::currentDateTime()});
+  emit stageSampleAdded(stage_samples_.size());
+}
+
+// ---------------------------------------------------------------------------
+// Read access
+// ---------------------------------------------------------------------------
+
+const QVector<CameraFrame>&    ExperimentSession::cameraFrames()    const {
+  return camera_frames_;
+}
+const QVector<VnaMeasurement>& ExperimentSession::vnaMeasurements() const {
+  return vna_measurements_;
+}
+const QVector<PumpSample>&     ExperimentSession::pumpSamples()     const {
+  return pump_samples_;
+}
+const QVector<LedSample>&      ExperimentSession::ledSamples()      const {
+  return led_samples_;
+}
+const QVector<SigGenSample>&   ExperimentSession::sigGenSamples()   const {
+  return sig_gen_samples_;
+}
+const QVector<StageSample>&    ExperimentSession::stageSamples()    const {
+  return stage_samples_;
+}
+
+// ---------------------------------------------------------------------------
+// Counts
+// ---------------------------------------------------------------------------
+
+int ExperimentSession::cameraFrameCount()   const {
+  return camera_frames_.size();
+}
+int ExperimentSession::vnaMeasurementCount() const {
+  return vna_measurements_.size();
+}
+int ExperimentSession::pumpSampleCount()    const {
+  return pump_samples_.size();
+}
+int ExperimentSession::ledSampleCount()     const {
+  return led_samples_.size();
+}
+int ExperimentSession::sigGenSampleCount()  const {
+  return sig_gen_samples_.size();
+}
+int ExperimentSession::stageSampleCount()   const {
+  return stage_samples_.size();
+}
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
+void ExperimentSession::clear() {
+  name_             = {};
+  description_      = {};
+  start_time_       = {};
+  end_time_         = {};
+  is_active_        = false;
+  camera_frames_.clear();
+  vna_measurements_.clear();
+  pump_samples_.clear();
+  led_samples_.clear();
+  sig_gen_samples_.clear();
+  stage_samples_.clear();
+}
+
+}  // namespace mwa::analysis

--- a/src/analysis/experiment_session.h
+++ b/src/analysis/experiment_session.h
@@ -1,0 +1,456 @@
+/**
+ * @file experiment_session.h
+ * @brief Experiment session data model for MWA.
+ * @author MWA Team
+ * @date 2026-04-05
+ *
+ * Defines the ExperimentSession class and its supporting data structs.
+ * An ExperimentSession accumulates hardware telemetry captured during a
+ * live experiment run. All stored types are Qt types — no vendor SDK types
+ * may appear here (see docs/hardware_data_flow.md, Interface Type Contract).
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <QDateTime>
+#include <QImage>
+#include <QObject>
+#include <QRect>
+#include <QString>
+#include <QVector>
+
+namespace mwa::analysis {
+
+// ---------------------------------------------------------------------------
+// Per-device data structs
+// ---------------------------------------------------------------------------
+
+/**
+ * @struct CameraFrame
+ * @brief One captured camera frame with its acquisition timestamp.
+ */
+struct CameraFrame {
+  QImage    image;      ///< Captured image (Qt type — never a Pylon grab result).
+  QDateTime timestamp;  ///< Wall-clock time at the moment of capture.
+};
+
+/**
+ * @struct VnaMeasurement
+ * @brief One complete VNA frequency sweep with its results.
+ *
+ * Frequencies and magnitudes are parallel arrays: @c frequencies[i] is the
+ * excitation frequency in Hz and @c magnitudes[i] is the S-parameter
+ * magnitude at that frequency in dB.
+ */
+struct VnaMeasurement {
+  double          start_frequency;  ///< Sweep start frequency (Hz).
+  double          stop_frequency;   ///< Sweep stop frequency (Hz).
+  int             num_points;       ///< Number of sweep points.
+  QVector<double> frequencies;      ///< Per-point frequency values (Hz).
+  QVector<double> magnitudes;       ///< Per-point S-parameter magnitudes (dB).
+  QDateTime       timestamp;        ///< Wall-clock time when the sweep completed.
+};
+
+/**
+ * @struct PumpSample
+ * @brief One syringe-pump telemetry sample.
+ */
+struct PumpSample {
+  double    position;   ///< Cumulative volume dispensed (µL).
+  double    flow_rate;  ///< Instantaneous flow rate at sample time (µL/min).
+  QDateTime timestamp;  ///< Wall-clock time of the sample.
+};
+
+/**
+ * @struct LedSample
+ * @brief One LED state sample.
+ */
+struct LedSample {
+  bool      power_on;  ///< true if the LED output is active.
+  double    intensity; ///< Brightness level (0.0–100.0 %).
+  QDateTime timestamp; ///< Wall-clock time of the sample.
+};
+
+/**
+ * @struct SigGenSample
+ * @brief One signal-generator parameter sample.
+ */
+struct SigGenSample {
+  double    frequency;  ///< Output frequency (Hz).
+  double    amplitude;  ///< Output amplitude (Vpp).
+  QDateTime timestamp;  ///< Wall-clock time of the sample.
+};
+
+/**
+ * @struct StageSample
+ * @brief One XYZ stage position sample.
+ */
+struct StageSample {
+  double    x;          ///< X-axis position (mm).
+  double    y;          ///< Y-axis position (mm).
+  double    z;          ///< Z-axis position (mm).
+  QDateTime timestamp;  ///< Wall-clock time of the sample.
+};
+
+// ---------------------------------------------------------------------------
+// ExperimentSession
+// ---------------------------------------------------------------------------
+
+/**
+ * @class ExperimentSession
+ * @brief Accumulates hardware telemetry for one experiment run.
+ *
+ * An ExperimentSession has a simple lifecycle: it starts with start(),
+ * accumulates data via add*() slots, and ends with end(). While active,
+ * data from any hardware controller can be fed directly from its signals
+ * into the corresponding add*() slot.
+ *
+ * All stored types are Qt primitives or Qt classes (QImage, QVector<double>,
+ * QDateTime, etc.). No vendor SDK types (Pylon, QmixSDK, SCPI objects) may
+ * appear here — they must be converted at the driver boundary before being
+ * passed to this class.
+ *
+ * @note The class is @b not thread-safe. All calls to add*() and lifecycle
+ *       methods must be made from the same thread (typically the GUI thread
+ *       via Qt queued connections from hardware worker threads).
+ *
+ * @see CameraFrame
+ * @see VnaMeasurement
+ * @see PumpSample
+ * @see LedSample
+ * @see SigGenSample
+ * @see StageSample
+ */
+class ExperimentSession : public QObject {
+  Q_OBJECT
+
+ public:
+  /**
+   * @brief Construct an idle session.
+   *
+   * @param parent Optional QObject parent for Qt ownership management.
+   */
+  explicit ExperimentSession(QObject* parent = nullptr);
+
+  // -------------------------------------------------------------------------
+  // Session lifecycle
+  // -------------------------------------------------------------------------
+
+  /**
+   * @brief Start a new session.
+   *
+   * Records the current wall-clock time as startTime(), clears any
+   * previously stored data, and sets the session to active. Emits
+   * sessionStarted().
+   *
+   * @param name        Human-readable session name (e.g. "Run 42").
+   * @param description Optional free-text description.
+   *
+   * @note Calling start() on an already-active session ends it first
+   *       (emits sessionEnded()), then starts the new one.
+   */
+  void start(const QString& name, const QString& description = {});
+
+  /**
+   * @brief End the active session.
+   *
+   * Records the current wall-clock time as endTime() and marks the session
+   * as inactive. Emits sessionEnded(). No-op if the session is already idle.
+   */
+  void end();
+
+  /**
+   * @brief Return true while data is being accumulated.
+   *
+   * @return true if start() has been called and end() has not yet been called.
+   */
+  [[nodiscard]] bool isActive() const;
+
+  // -------------------------------------------------------------------------
+  // Session metadata
+  // -------------------------------------------------------------------------
+
+  /**
+   * @brief Return the session name set by start().
+   *
+   * @return Session name, or an empty string if the session has never started.
+   */
+  [[nodiscard]] QString name() const;
+
+  /**
+   * @brief Return the optional description set by start().
+   *
+   * @return Session description, or an empty string if not provided.
+   */
+  [[nodiscard]] QString description() const;
+
+  /**
+   * @brief Return the wall-clock time when start() was last called.
+   *
+   * @return Start timestamp, or a null QDateTime if the session has never
+   *         started.
+   */
+  [[nodiscard]] QDateTime startTime() const;
+
+  /**
+   * @brief Return the wall-clock time when end() was last called.
+   *
+   * @return End timestamp, or a null QDateTime if the session is still active
+   *         or has never ended.
+   */
+  [[nodiscard]] QDateTime endTime() const;
+
+  // -------------------------------------------------------------------------
+  // Data ingestion — connect hardware controller signals to these slots
+  // -------------------------------------------------------------------------
+
+  /**
+   * @brief Append a camera frame.
+   *
+   * Timestamps the frame at the moment of the call and appends it to the
+   * internal frame list. Emits cameraFrameAdded() with the new total count.
+   *
+   * @param image The captured frame (Qt Grayscale8 or RGB32 image).
+   *
+   * @note Silently ignored if the session is not active.
+   */
+  void addCameraFrame(const QImage& image);
+
+  /**
+   * @brief Append a VNA measurement.
+   *
+   * Records a completed frequency sweep. @p frequencies and @p magnitudes
+   * must be the same length (@p num_points); if they differ the call is a
+   * no-op and a warning is logged.
+   *
+   * @param frequencies      Per-point excitation frequencies (Hz).
+   * @param magnitudes       Per-point S-parameter magnitudes (dB).
+   * @param start_frequency  Sweep start frequency (Hz).
+   * @param stop_frequency   Sweep stop frequency (Hz).
+   * @param num_points       Number of sweep points.
+   *
+   * @note Silently ignored if the session is not active.
+   */
+  void addVnaMeasurement(const QVector<double>& frequencies,
+                         const QVector<double>& magnitudes,
+                         double start_frequency, double stop_frequency,
+                         int num_points);
+
+  /**
+   * @brief Append a pump telemetry sample.
+   *
+   * @param position  Cumulative volume dispensed (µL).
+   * @param flow_rate Instantaneous flow rate (µL/min).
+   *
+   * @note Silently ignored if the session is not active.
+   */
+  void addPumpSample(double position, double flow_rate);
+
+  /**
+   * @brief Append an LED state sample.
+   *
+   * @param power_on true if the LED output is currently active.
+   * @param intensity Brightness level (0.0–100.0 %).
+   *
+   * @note Silently ignored if the session is not active.
+   */
+  void addLedSample(bool power_on, double intensity);
+
+  /**
+   * @brief Append a signal-generator parameter sample.
+   *
+   * @param frequency Output frequency (Hz).
+   * @param amplitude Output amplitude (Vpp).
+   *
+   * @note Silently ignored if the session is not active.
+   */
+  void addSigGenSample(double frequency, double amplitude);
+
+  /**
+   * @brief Append an XYZ stage position sample.
+   *
+   * @param x X-axis position (mm).
+   * @param y Y-axis position (mm).
+   * @param z Z-axis position (mm).
+   *
+   * @note Silently ignored if the session is not active.
+   */
+  void addStageSample(double x, double y, double z);
+
+  // -------------------------------------------------------------------------
+  // Read access
+  // -------------------------------------------------------------------------
+
+  /**
+   * @brief Return all camera frames accumulated in this session.
+   *
+   * @return Const reference to the internal frame list.
+   */
+  [[nodiscard]] const QVector<CameraFrame>& cameraFrames() const;
+
+  /**
+   * @brief Return all VNA measurements accumulated in this session.
+   *
+   * @return Const reference to the internal measurement list.
+   */
+  [[nodiscard]] const QVector<VnaMeasurement>& vnaMeasurements() const;
+
+  /**
+   * @brief Return all pump samples accumulated in this session.
+   *
+   * @return Const reference to the internal pump sample list.
+   */
+  [[nodiscard]] const QVector<PumpSample>& pumpSamples() const;
+
+  /**
+   * @brief Return all LED samples accumulated in this session.
+   *
+   * @return Const reference to the internal LED sample list.
+   */
+  [[nodiscard]] const QVector<LedSample>& ledSamples() const;
+
+  /**
+   * @brief Return all signal-generator samples accumulated in this session.
+   *
+   * @return Const reference to the internal signal-generator sample list.
+   */
+  [[nodiscard]] const QVector<SigGenSample>& sigGenSamples() const;
+
+  /**
+   * @brief Return all stage position samples accumulated in this session.
+   *
+   * @return Const reference to the internal stage sample list.
+   */
+  [[nodiscard]] const QVector<StageSample>& stageSamples() const;
+
+  // -------------------------------------------------------------------------
+  // Convenience counts
+  // -------------------------------------------------------------------------
+
+  /**
+   * @brief Return the number of camera frames stored in this session.
+   *
+   * @return Frame count.
+   */
+  [[nodiscard]] int cameraFrameCount() const;
+
+  /**
+   * @brief Return the number of VNA measurements stored in this session.
+   *
+   * @return Measurement count.
+   */
+  [[nodiscard]] int vnaMeasurementCount() const;
+
+  /**
+   * @brief Return the number of pump samples stored in this session.
+   *
+   * @return Sample count.
+   */
+  [[nodiscard]] int pumpSampleCount() const;
+
+  /**
+   * @brief Return the number of LED samples stored in this session.
+   *
+   * @return Sample count.
+   */
+  [[nodiscard]] int ledSampleCount() const;
+
+  /**
+   * @brief Return the number of signal-generator samples stored.
+   *
+   * @return Sample count.
+   */
+  [[nodiscard]] int sigGenSampleCount() const;
+
+  /**
+   * @brief Return the number of stage position samples stored.
+   *
+   * @return Sample count.
+   */
+  [[nodiscard]] int stageSampleCount() const;
+
+  // -------------------------------------------------------------------------
+  // Reset
+  // -------------------------------------------------------------------------
+
+  /**
+   * @brief Clear all accumulated data and reset metadata.
+   *
+   * Resets the session to its freshly-constructed idle state. Does not
+   * emit sessionEnded() — use end() for a graceful close first if needed.
+   */
+  void clear();
+
+ signals:
+  /**
+   * @brief Emitted when a session starts.
+   *
+   * @param name The session name passed to start().
+   */
+  void sessionStarted(const QString& name);
+
+  /**
+   * @brief Emitted when a session ends via end().
+   */
+  void sessionEnded();
+
+  /**
+   * @brief Emitted after each successful addCameraFrame() call.
+   *
+   * @param count Total number of frames stored so far.
+   */
+  void cameraFrameAdded(int count);
+
+  /**
+   * @brief Emitted after each successful addVnaMeasurement() call.
+   *
+   * @param count Total number of VNA measurements stored so far.
+   */
+  void vnaMeasurementAdded(int count);
+
+  /**
+   * @brief Emitted after each successful addPumpSample() call.
+   *
+   * @param count Total number of pump samples stored so far.
+   */
+  void pumpSampleAdded(int count);
+
+  /**
+   * @brief Emitted after each successful addLedSample() call.
+   *
+   * @param count Total number of LED samples stored so far.
+   */
+  void ledSampleAdded(int count);
+
+  /**
+   * @brief Emitted after each successful addSigGenSample() call.
+   *
+   * @param count Total number of signal-generator samples stored so far.
+   */
+  void sigGenSampleAdded(int count);
+
+  /**
+   * @brief Emitted after each successful addStageSample() call.
+   *
+   * @param count Total number of stage position samples stored so far.
+   */
+  void stageSampleAdded(int count);
+
+ private:
+  QString   name_;         ///< Session name.
+  QString   description_;  ///< Optional session description.
+  QDateTime start_time_;   ///< Wall-clock time when start() was called.
+  QDateTime end_time_;     ///< Wall-clock time when end() was called.
+  bool      is_active_{false};  ///< true while accumulating data.
+
+  QVector<CameraFrame>    camera_frames_;     ///< Captured camera frames.
+  QVector<VnaMeasurement> vna_measurements_;  ///< Completed VNA sweeps.
+  QVector<PumpSample>     pump_samples_;      ///< Pump telemetry timeline.
+  QVector<LedSample>      led_samples_;       ///< LED state timeline.
+  QVector<SigGenSample>   sig_gen_samples_;   ///< Signal-generator timeline.
+  QVector<StageSample>    stage_samples_;     ///< Stage position timeline.
+};
+
+}  // namespace mwa::analysis

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -334,6 +334,20 @@ target_link_libraries(test_error_handler PRIVATE
 add_test(NAME test_error_handler COMMAND test_error_handler)
 
 # ---------------------------------------------------------------------------
+# ExperimentSession tests
+# ---------------------------------------------------------------------------
+add_executable(test_experiment_session test_experiment_session.cpp)
+
+target_link_libraries(test_experiment_session PRIVATE
+  MwaAnalysis
+  Qt6::Core
+  Qt6::Gui
+  Qt6::Test
+)
+
+add_test(NAME test_experiment_session COMMAND test_experiment_session)
+
+# ---------------------------------------------------------------------------
 # SerialUtils tests (require Qt6::SerialPort)
 # ---------------------------------------------------------------------------
 if(TARGET Qt6::SerialPort)

--- a/tests/test_experiment_session.cpp
+++ b/tests/test_experiment_session.cpp
@@ -1,0 +1,354 @@
+/**
+ * @file test_experiment_session.cpp
+ * @brief Unit tests for mwa::analysis::ExperimentSession.
+ */
+
+#include <QtTest>
+#include <QSignalSpy>
+#include <QImage>
+
+#include "analysis/experiment_session.h"
+
+using namespace mwa::analysis;
+
+class TestExperimentSession : public QObject {
+  Q_OBJECT
+
+ private slots:
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  void initialStateIsIdle() {
+    ExperimentSession s;
+    QVERIFY(!s.isActive());
+    QVERIFY(s.name().isEmpty());
+    QVERIFY(s.description().isEmpty());
+    QVERIFY(!s.startTime().isValid());
+    QVERIFY(!s.endTime().isValid());
+  }
+
+  void startActivatesSession() {
+    ExperimentSession s;
+    s.start("Run 1");
+    QVERIFY(s.isActive());
+    QCOMPARE(s.name(), QString("Run 1"));
+    QVERIFY(s.startTime().isValid());
+    QVERIFY(!s.endTime().isValid());
+  }
+
+  void startWithDescription() {
+    ExperimentSession s;
+    s.start("Run 2", "Acoustic focusing test");
+    QCOMPARE(s.description(), QString("Acoustic focusing test"));
+  }
+
+  void endDeactivatesSession() {
+    ExperimentSession s;
+    s.start("Run 1");
+    s.end();
+    QVERIFY(!s.isActive());
+    QVERIFY(s.endTime().isValid());
+    QVERIFY(s.endTime() >= s.startTime());
+  }
+
+  void endOnIdleSessionIsNoOp() {
+    ExperimentSession s;
+    // Must not crash or change state
+    s.end();
+    QVERIFY(!s.isActive());
+    QVERIFY(!s.endTime().isValid());
+  }
+
+  void startWhileActiveEndsFirstSession() {
+    ExperimentSession s;
+
+    QSignalSpy ended(&s, &ExperimentSession::sessionEnded);
+    QSignalSpy started(&s, &ExperimentSession::sessionStarted);
+
+    s.start("Run 1");
+    s.start("Run 2");  // should end Run 1 first
+
+    QCOMPARE(ended.count(), 1);
+    QCOMPARE(started.count(), 2);
+    QCOMPARE(s.name(), QString("Run 2"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Signals from lifecycle
+  // -------------------------------------------------------------------------
+
+  void sessionStartedSignalCarriesName() {
+    ExperimentSession s;
+    QSignalSpy spy(&s, &ExperimentSession::sessionStarted);
+    s.start("MySess");
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(0).toString(), QString("MySess"));
+  }
+
+  void sessionEndedSignalEmittedOnce() {
+    ExperimentSession s;
+    QSignalSpy spy(&s, &ExperimentSession::sessionEnded);
+    s.start("R");
+    s.end();
+    QCOMPARE(spy.count(), 1);
+  }
+
+  // -------------------------------------------------------------------------
+  // Data ingestion: addCameraFrame
+  // -------------------------------------------------------------------------
+
+  void cameraFrameNotAcceptedWhenIdle() {
+    ExperimentSession s;
+    s.addCameraFrame(QImage(10, 10, QImage::Format_Grayscale8));
+    QCOMPARE(s.cameraFrameCount(), 0);
+  }
+
+  void cameraFrameStoredWhenActive() {
+    ExperimentSession s;
+    s.start("R");
+    QImage img(640, 480, QImage::Format_Grayscale8);
+    img.fill(128);
+    s.addCameraFrame(img);
+    QCOMPARE(s.cameraFrameCount(), 1);
+    QCOMPARE(s.cameraFrames().at(0).image.width(), 640);
+    QCOMPARE(s.cameraFrames().at(0).image.height(), 480);
+    QVERIFY(s.cameraFrames().at(0).timestamp.isValid());
+  }
+
+  void cameraFrameCountSignalEmittedWithCorrectCount() {
+    ExperimentSession s;
+    s.start("R");
+    QSignalSpy spy(&s, &ExperimentSession::cameraFrameAdded);
+
+    s.addCameraFrame(QImage(1, 1, QImage::Format_Grayscale8));
+    s.addCameraFrame(QImage(1, 1, QImage::Format_Grayscale8));
+    s.addCameraFrame(QImage(1, 1, QImage::Format_Grayscale8));
+
+    QCOMPARE(spy.count(), 3);
+    QCOMPARE(spy.at(0).at(0).toInt(), 1);
+    QCOMPARE(spy.at(1).at(0).toInt(), 2);
+    QCOMPARE(spy.at(2).at(0).toInt(), 3);
+  }
+
+  // -------------------------------------------------------------------------
+  // Data ingestion: addVnaMeasurement
+  // -------------------------------------------------------------------------
+
+  void vnaMeasurementNotAcceptedWhenIdle() {
+    ExperimentSession s;
+    s.addVnaMeasurement({1e9, 2e9}, {-40.0, -38.0}, 1e9, 2e9, 2);
+    QCOMPARE(s.vnaMeasurementCount(), 0);
+  }
+
+  void vnaMeasurementStoredWhenActive() {
+    ExperimentSession s;
+    s.start("R");
+    QVector<double> freqs = {1e9, 2e9, 3e9};
+    QVector<double> mags  = {-40.0, -35.0, -42.0};
+    s.addVnaMeasurement(freqs, mags, 1e9, 3e9, 3);
+
+    QCOMPARE(s.vnaMeasurementCount(), 1);
+    const auto& m = s.vnaMeasurements().at(0);
+    QCOMPARE(m.start_frequency, 1e9);
+    QCOMPARE(m.stop_frequency, 3e9);
+    QCOMPARE(m.num_points, 3);
+    QCOMPARE(m.frequencies, freqs);
+    QCOMPARE(m.magnitudes, mags);
+    QVERIFY(m.timestamp.isValid());
+  }
+
+  void vnaMeasurementDiscardedOnLengthMismatch() {
+    ExperimentSession s;
+    s.start("R");
+    QSignalSpy spy(&s, &ExperimentSession::vnaMeasurementAdded);
+
+    // frequencies has 3 elements, magnitudes has 2 — must be rejected
+    s.addVnaMeasurement({1e9, 2e9, 3e9}, {-40.0, -35.0}, 1e9, 3e9, 3);
+
+    QCOMPARE(s.vnaMeasurementCount(), 0);
+    QCOMPARE(spy.count(), 0);
+  }
+
+  void vnaMeasurementSignalEmittedWithCorrectCount() {
+    ExperimentSession s;
+    s.start("R");
+    QSignalSpy spy(&s, &ExperimentSession::vnaMeasurementAdded);
+
+    s.addVnaMeasurement({1e9}, {-40.0}, 1e9, 1e9, 1);
+    s.addVnaMeasurement({2e9}, {-38.0}, 2e9, 2e9, 1);
+
+    QCOMPARE(spy.count(), 2);
+    QCOMPARE(spy.at(0).at(0).toInt(), 1);
+    QCOMPARE(spy.at(1).at(0).toInt(), 2);
+  }
+
+  // -------------------------------------------------------------------------
+  // Data ingestion: addPumpSample
+  // -------------------------------------------------------------------------
+
+  void pumpSampleNotAcceptedWhenIdle() {
+    ExperimentSession s;
+    s.addPumpSample(10.0, 5.0);
+    QCOMPARE(s.pumpSampleCount(), 0);
+  }
+
+  void pumpSampleStoredWhenActive() {
+    ExperimentSession s;
+    s.start("R");
+    s.addPumpSample(12.5, 3.0);
+    QCOMPARE(s.pumpSampleCount(), 1);
+    QCOMPARE(s.pumpSamples().at(0).position, 12.5);
+    QCOMPARE(s.pumpSamples().at(0).flow_rate, 3.0);
+    QVERIFY(s.pumpSamples().at(0).timestamp.isValid());
+  }
+
+  // -------------------------------------------------------------------------
+  // Data ingestion: addLedSample
+  // -------------------------------------------------------------------------
+
+  void ledSampleNotAcceptedWhenIdle() {
+    ExperimentSession s;
+    s.addLedSample(true, 75.0);
+    QCOMPARE(s.ledSampleCount(), 0);
+  }
+
+  void ledSampleStoredWhenActive() {
+    ExperimentSession s;
+    s.start("R");
+    s.addLedSample(true, 75.0);
+    QCOMPARE(s.ledSampleCount(), 1);
+    QVERIFY(s.ledSamples().at(0).power_on);
+    QCOMPARE(s.ledSamples().at(0).intensity, 75.0);
+    QVERIFY(s.ledSamples().at(0).timestamp.isValid());
+  }
+
+  // -------------------------------------------------------------------------
+  // Data ingestion: addSigGenSample
+  // -------------------------------------------------------------------------
+
+  void sigGenSampleNotAcceptedWhenIdle() {
+    ExperimentSession s;
+    s.addSigGenSample(1e6, 2.5);
+    QCOMPARE(s.sigGenSampleCount(), 0);
+  }
+
+  void sigGenSampleStoredWhenActive() {
+    ExperimentSession s;
+    s.start("R");
+    s.addSigGenSample(1e6, 2.5);
+    QCOMPARE(s.sigGenSampleCount(), 1);
+    QCOMPARE(s.sigGenSamples().at(0).frequency, 1e6);
+    QCOMPARE(s.sigGenSamples().at(0).amplitude, 2.5);
+    QVERIFY(s.sigGenSamples().at(0).timestamp.isValid());
+  }
+
+  // -------------------------------------------------------------------------
+  // Data ingestion: addStageSample
+  // -------------------------------------------------------------------------
+
+  void stageSampleNotAcceptedWhenIdle() {
+    ExperimentSession s;
+    s.addStageSample(1.0, 2.0, 3.0);
+    QCOMPARE(s.stageSampleCount(), 0);
+  }
+
+  void stageSampleStoredWhenActive() {
+    ExperimentSession s;
+    s.start("R");
+    s.addStageSample(1.5, 2.5, 0.1);
+    QCOMPARE(s.stageSampleCount(), 1);
+    QCOMPARE(s.stageSamples().at(0).x, 1.5);
+    QCOMPARE(s.stageSamples().at(0).y, 2.5);
+    QCOMPARE(s.stageSamples().at(0).z, 0.1);
+    QVERIFY(s.stageSamples().at(0).timestamp.isValid());
+  }
+
+  // -------------------------------------------------------------------------
+  // No data accepted after end()
+  // -------------------------------------------------------------------------
+
+  void noDataAcceptedAfterEnd() {
+    ExperimentSession s;
+    s.start("R");
+    s.end();
+
+    s.addCameraFrame(QImage(1, 1, QImage::Format_Grayscale8));
+    s.addVnaMeasurement({1e9}, {-40.0}, 1e9, 1e9, 1);
+    s.addPumpSample(1.0, 1.0);
+    s.addLedSample(true, 50.0);
+    s.addSigGenSample(1e6, 1.0);
+    s.addStageSample(0.0, 0.0, 0.0);
+
+    QCOMPARE(s.cameraFrameCount(), 0);
+    QCOMPARE(s.vnaMeasurementCount(), 0);
+    QCOMPARE(s.pumpSampleCount(), 0);
+    QCOMPARE(s.ledSampleCount(), 0);
+    QCOMPARE(s.sigGenSampleCount(), 0);
+    QCOMPARE(s.stageSampleCount(), 0);
+  }
+
+  // -------------------------------------------------------------------------
+  // clear()
+  // -------------------------------------------------------------------------
+
+  void clearResetsEverything() {
+    ExperimentSession s;
+    s.start("R");
+    s.addCameraFrame(QImage(1, 1, QImage::Format_Grayscale8));
+    s.addPumpSample(5.0, 2.0);
+    s.end();
+
+    s.clear();
+
+    QVERIFY(!s.isActive());
+    QVERIFY(s.name().isEmpty());
+    QVERIFY(!s.startTime().isValid());
+    QVERIFY(!s.endTime().isValid());
+    QCOMPARE(s.cameraFrameCount(), 0);
+    QCOMPARE(s.pumpSampleCount(), 0);
+  }
+
+  // -------------------------------------------------------------------------
+  // Data persists across start→end without clear
+  // -------------------------------------------------------------------------
+
+  void endDoesNotClearData() {
+    ExperimentSession s;
+    s.start("R");
+    s.addCameraFrame(QImage(1, 1, QImage::Format_Grayscale8));
+    s.end();
+
+    // After end() data must still be readable
+    QCOMPARE(s.cameraFrameCount(), 1);
+  }
+
+  // -------------------------------------------------------------------------
+  // Multiple devices simultaneously
+  // -------------------------------------------------------------------------
+
+  void allDeviceTypesAccumulateIndependently() {
+    ExperimentSession s;
+    s.start("Multi");
+
+    for (int i = 0; i < 5; ++i)
+      s.addCameraFrame(QImage(1, 1, QImage::Format_Grayscale8));
+    for (int i = 0; i < 3; ++i)
+      s.addVnaMeasurement({1e9}, {-40.0}, 1e9, 1e9, 1);
+    for (int i = 0; i < 7; ++i)
+      s.addPumpSample(static_cast<double>(i), 1.0);
+    s.addLedSample(true, 50.0);
+    s.addSigGenSample(1e6, 1.0);
+    s.addStageSample(0.0, 0.0, 0.0);
+
+    QCOMPARE(s.cameraFrameCount(), 5);
+    QCOMPARE(s.vnaMeasurementCount(), 3);
+    QCOMPARE(s.pumpSampleCount(), 7);
+    QCOMPARE(s.ledSampleCount(), 1);
+    QCOMPARE(s.sigGenSampleCount(), 1);
+    QCOMPARE(s.stageSampleCount(), 1);
+  }
+};
+
+QTEST_MAIN(TestExperimentSession)
+#include "test_experiment_session.moc"


### PR DESCRIPTION
## PR Handoff Summary for Owner

### What Changed
- New `MwaAnalysis` static library added (`src/analysis/`)
- `ExperimentSession` class (`QObject`) — accumulates hardware telemetry for one experiment run
- Six per-device data structs: `CameraFrame`, `VnaMeasurement`, `PumpSample`, `LedSample`, `SigGenSample`, `StageSample`
- `src/CMakeLists.txt` updated to include the new `analysis` subdirectory
- 29 unit tests in `tests/test_experiment_session.cpp`

### Requirement IDs Addressed
- ANA-REQ-001 (Image Batch Management — foundation layer)
- ANA-REQ-007 (Data Export — foundation layer; concrete export in MWA-12-C/D)

### What to Test (Owner Manual Testing)
This is a pure data model with no GUI — verify through code review and test results:
1. Confirm `src/analysis/experiment_session.h` uses **only Qt types** — no Pylon, QmixSDK, or other vendor types
2. Confirm all 6 device data structs use `QDateTime` for timestamps
3. Check that `addVnaMeasurement()` length-mismatch guard is present and tested
4. Confirm `clear()` resets all fields including metadata
5. Verify the `MwaAnalysis` library appears in the build output without warnings

### What to Focus On
- **Type firewall compliance** — the core requirement: zero vendor SDK types in `experiment_session.h`. Any Pylon/QmixSDK type appearing here would be a critical regression
- `start()` calling `end()` internally when already active — this prevents orphaned sessions if the user forgets to close
- `end()` preserves data (data survives after the session ends so it can be read/exported)
- Thread safety note: documented in the header — all calls must be from the same thread. This is fine for Phase 1 (GUI thread only); Phase 2 will add cross-thread guards if needed

### Doxygen Documentation Check
- `@file` block on both `.h` and `.cpp` ✓
- `@class ExperimentSession` with `@brief`, `@note` (thread safety), `@see` references ✓
- All 6 data structs documented with `@struct` and `///<` field comments ✓
- Every public method has `@brief`, `@param`, `@return`, and `@note` where applicable ✓
- All signals documented ✓

### Test Results Summary
- Total tests: 29
- Passed: 29
- Failed: 0
- Coverage: all public methods and all lifecycle paths exercised
- Platforms tested: macOS (local)

### Known Issues / Limitations
- None. This is a pure data model — no hardware communication, no threading