### PR TITLE
feat(MWA-12-C): VNA data export to CSV

### DIFF
--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library(MwaAnalysis STATIC
   experiment_session.cpp
   session_serializer.h
   session_serializer.cpp
+  vna_csv_exporter.h
+  vna_csv_exporter.cpp
 )
 
 target_include_directories(MwaAnalysis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/src/analysis/vna_csv_exporter.cpp
+++ b/src/analysis/vna_csv_exporter.cpp
@@ -46,13 +46,14 @@ bool VnaCsvExporter::exportToFile(const ExperimentSession& session,
     const QString ts = m.timestamp.isValid()
                            ? m.timestamp.toString(Qt::ISODateWithMs)
                            : QString{};
+    const QString start_freq = QString::number(m.start_frequency, 'f', 0);
+    const QString stop_freq  = QString::number(m.stop_frequency, 'f', 0);
 
-    const int num_points = m.frequencies.size();
-    for (int i = 0; i < num_points; ++i) {
+    for (int i = 0; i < m.frequencies.size(); ++i) {
       out << sweep_idx << ','
           << ts << ','
-          << QString::number(m.start_frequency, 'f', 0) << ','
-          << QString::number(m.stop_frequency, 'f', 0) << ','
+          << start_freq << ','
+          << stop_freq << ','
           << QString::number(m.frequencies[i], 'f', 6) << ','
           << QString::number(m.magnitudes[i], 'f', 6) << '\n';
     }

--- a/src/analysis/vna_csv_exporter.cpp
+++ b/src/analysis/vna_csv_exporter.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file vna_csv_exporter.cpp
+ * @brief VnaCsvExporter implementation.
+ * @author MWA Team
+ * @date 2026-04-05
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#include "analysis/vna_csv_exporter.h"
+
+#include <QFile>
+#include <QTextStream>
+
+namespace mwa::analysis {
+
+// ---------------------------------------------------------------------------
+// Static member
+// ---------------------------------------------------------------------------
+
+QString VnaCsvExporter::last_error_;
+
+// ---------------------------------------------------------------------------
+// exportToFile()
+// ---------------------------------------------------------------------------
+
+bool VnaCsvExporter::exportToFile(const ExperimentSession& session,
+                                   const QString& file_path) {
+  QFile file(file_path);
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate |
+                 QIODevice::Text)) {
+    last_error_ =
+        QStringLiteral("Cannot open file for writing: ") + file_path;
+    return false;
+  }
+
+  QTextStream out(&file);
+
+  out << QStringLiteral(
+      "sweep_index,timestamp,start_frequency_hz,stop_frequency_hz,"
+      "frequency_hz,magnitude_db\n");
+
+  const QVector<VnaMeasurement>& measurements = session.vnaMeasurements();
+  for (int sweep_idx = 0; sweep_idx < measurements.size(); ++sweep_idx) {
+    const VnaMeasurement& m = measurements[sweep_idx];
+    const QString ts = m.timestamp.isValid()
+                           ? m.timestamp.toString(Qt::ISODateWithMs)
+                           : QString{};
+
+    const int num_points = m.frequencies.size();
+    for (int i = 0; i < num_points; ++i) {
+      out << sweep_idx << ','
+          << ts << ','
+          << QString::number(m.start_frequency, 'f', 0) << ','
+          << QString::number(m.stop_frequency, 'f', 0) << ','
+          << QString::number(m.frequencies[i], 'f', 6) << ','
+          << QString::number(m.magnitudes[i], 'f', 6) << '\n';
+    }
+  }
+
+  if (out.status() != QTextStream::Ok) {
+    last_error_ =
+        QStringLiteral("Write failed (disk full?): ") + file_path;
+    return false;
+  }
+
+  last_error_.clear();
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// lastError()
+// ---------------------------------------------------------------------------
+
+QString VnaCsvExporter::lastError() { return last_error_; }
+
+}  // namespace mwa::analysis

--- a/src/analysis/vna_csv_exporter.h
+++ b/src/analysis/vna_csv_exporter.h
@@ -1,0 +1,83 @@
+/**
+ * @file vna_csv_exporter.h
+ * @brief CSV export for VNA measurements stored in an ExperimentSession.
+ * @author MWA Team
+ * @date 2026-04-05
+ *
+ * Provides VnaCsvExporter, a stateless utility class that writes all
+ * VnaMeasurement entries from an ExperimentSession to a single CSV file.
+ *
+ * ### CSV Format
+ * The first line is a fixed header row.  Each subsequent line represents one
+ * data point from one sweep:
+ *
+ * @code
+ * sweep_index,timestamp,start_frequency_hz,stop_frequency_hz,frequency_hz,magnitude_db
+ * 0,2026-04-05T10:00:00.000,1000000,10000000,1000000,-12.5
+ * @endcode
+ *
+ * - @c sweep_index: zero-based index of the sweep within the session.
+ * - @c timestamp: ISO-8601 with millisecond precision (Qt::ISODateWithMs).
+ * - @c start_frequency_hz / @c stop_frequency_hz: sweep range (Hz).
+ * - @c frequency_hz: excitation frequency of this point (Hz).
+ * - @c magnitude_db: S-parameter magnitude at this point (dB).
+ *
+ * If the session contains no VNA measurements the file is created with only
+ * the header row and exportToFile() returns @c true.
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <QString>
+
+#include "analysis/experiment_session.h"
+
+namespace mwa::analysis {
+
+/**
+ * @class VnaCsvExporter
+ * @brief Exports all VNA measurements from an ExperimentSession to a CSV file.
+ *
+ * All methods are static.  A static @c lastError() accessor returns a
+ * human-readable message for the most recent failure.
+ *
+ * @note Not thread-safe: do not call exportToFile() concurrently from multiple
+ *       threads without external synchronization.
+ *
+ * @see ExperimentSession
+ * @see VnaMeasurement
+ */
+class VnaCsvExporter {
+ public:
+  /**
+   * @brief Write all VNA measurements from @p session to a CSV file.
+   *
+   * Overwrites any existing file at @p file_path.  Produces a header row
+   * followed by one data row per sweep point across all sweeps.  If the
+   * session contains no VNA measurements, only the header row is written and
+   * the method returns @c true.
+   *
+   * @param session   The session whose VNA measurements to export.
+   * @param file_path Absolute or relative path to the destination CSV file.
+   * @return @c true on success; @c false if the file cannot be opened or
+   *         written (lastError() describes the failure).
+   */
+  static bool exportToFile(const ExperimentSession& session,
+                            const QString& file_path);
+
+  /**
+   * @brief Return a human-readable description of the last error.
+   *
+   * Empty string if the last exportToFile() call succeeded.
+   *
+   * @return Error message string.
+   */
+  [[nodiscard]] static QString lastError();
+
+ private:
+  static QString last_error_;  ///< Most recent error description.
+};
+
+}  // namespace mwa::analysis

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -362,6 +362,19 @@ target_link_libraries(test_session_serializer PRIVATE
 add_test(NAME test_session_serializer COMMAND test_session_serializer)
 
 # ---------------------------------------------------------------------------
+# VnaCsvExporter tests
+# ---------------------------------------------------------------------------
+add_executable(test_vna_csv_exporter test_vna_csv_exporter.cpp)
+
+target_link_libraries(test_vna_csv_exporter PRIVATE
+  MwaAnalysis
+  Qt6::Core
+  Qt6::Test
+)
+
+add_test(NAME test_vna_csv_exporter COMMAND test_vna_csv_exporter)
+
+# ---------------------------------------------------------------------------
 # SerialUtils tests (require Qt6::SerialPort)
 # ---------------------------------------------------------------------------
 if(TARGET Qt6::SerialPort)

--- a/tests/test_vna_csv_exporter.cpp
+++ b/tests/test_vna_csv_exporter.cpp
@@ -1,0 +1,321 @@
+/**
+ * @file test_vna_csv_exporter.cpp
+ * @brief Unit tests for mwa::analysis::VnaCsvExporter.
+ */
+
+#include <QtTest>
+#include <QFile>
+#include <QTemporaryFile>
+#include <QTextStream>
+
+#include "analysis/experiment_session.h"
+#include "analysis/vna_csv_exporter.h"
+
+using namespace mwa::analysis;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Create a temporary file path (file opened then closed; path persists).
+static QString tempFilePath() {
+  QTemporaryFile f;
+  f.setAutoRemove(false);
+  const bool opened = f.open();
+  Q_ASSERT(opened);
+  f.close();
+  return f.fileName();
+}
+
+/// Read all lines from @p path, stripping trailing newlines.
+static QStringList readLines(const QString& path) {
+  QFile file(path);
+  if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+    return {};
+  QTextStream in(&file);
+  QStringList lines;
+  while (!in.atEnd()) {
+    const QString line = in.readLine();
+    if (!line.isEmpty())
+      lines.append(line);
+  }
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Test class
+// ---------------------------------------------------------------------------
+
+class TestVnaCsvExporter : public QObject {
+  Q_OBJECT
+
+ private slots:
+
+  // -------------------------------------------------------------------------
+  // Empty session: only header row written
+  // -------------------------------------------------------------------------
+
+  void exportToFile_emptySession_writesHeaderOnly() {
+    ExperimentSession session;
+    session.start("Empty");
+    session.end();
+
+    const QString path = tempFilePath();
+    QVERIFY(VnaCsvExporter::exportToFile(session, path));
+    QVERIFY(VnaCsvExporter::lastError().isEmpty());
+
+    const QStringList lines = readLines(path);
+    // Exactly one line: the header.
+    QCOMPARE(lines.size(), 1);
+    QVERIFY(lines.at(0).startsWith(
+        QStringLiteral("sweep_index,timestamp")));
+  }
+
+  // -------------------------------------------------------------------------
+  // Header format: correct column names
+  // -------------------------------------------------------------------------
+
+  void exportToFile_headerContainsAllColumns() {
+    ExperimentSession session;
+    session.start("H");
+    session.end();
+
+    const QString path = tempFilePath();
+    QVERIFY(VnaCsvExporter::exportToFile(session, path));
+
+    const QStringList lines = readLines(path);
+    QVERIFY(!lines.isEmpty());
+    const QStringList cols = lines.at(0).split(',');
+    QCOMPARE(cols.size(), 6);
+    QCOMPARE(cols.at(0), QStringLiteral("sweep_index"));
+    QCOMPARE(cols.at(1), QStringLiteral("timestamp"));
+    QCOMPARE(cols.at(2), QStringLiteral("start_frequency_hz"));
+    QCOMPARE(cols.at(3), QStringLiteral("stop_frequency_hz"));
+    QCOMPARE(cols.at(4), QStringLiteral("frequency_hz"));
+    QCOMPARE(cols.at(5), QStringLiteral("magnitude_db"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Single sweep: row count = num_points + 1 (header)
+  // -------------------------------------------------------------------------
+
+  void exportToFile_singleSweep_rowCountMatchesNumPoints() {
+    ExperimentSession session;
+    session.start("S1");
+    const QVector<double> freqs = {1e6, 2e6, 3e6, 4e6, 5e6};
+    const QVector<double> mags  = {-10.0, -12.0, -11.5, -13.0, -9.5};
+    session.addVnaMeasurement(1e6, 5e6, 5, freqs, mags);
+    session.end();
+
+    const QString path = tempFilePath();
+    QVERIFY(VnaCsvExporter::exportToFile(session, path));
+
+    const QStringList lines = readLines(path);
+    // 1 header + 5 data rows.
+    QCOMPARE(lines.size(), 6);
+  }
+
+  // -------------------------------------------------------------------------
+  // Single sweep: sweep_index is always 0
+  // -------------------------------------------------------------------------
+
+  void exportToFile_singleSweep_sweepIndexIsZero() {
+    ExperimentSession session;
+    session.start("S1");
+    const QVector<double> freqs = {1e6, 2e6};
+    const QVector<double> mags  = {-10.0, -11.0};
+    session.addVnaMeasurement(1e6, 2e6, 2, freqs, mags);
+    session.end();
+
+    const QString path = tempFilePath();
+    QVERIFY(VnaCsvExporter::exportToFile(session, path));
+
+    const QStringList lines = readLines(path);
+    for (int i = 1; i < lines.size(); ++i) {
+      const QStringList cols = lines.at(i).split(',');
+      QCOMPARE(cols.at(0), QStringLiteral("0"));
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Multiple sweeps: total rows = sum of all points + 1 (header)
+  // -------------------------------------------------------------------------
+
+  void exportToFile_multiSweep_totalRowCount() {
+    ExperimentSession session;
+    session.start("M");
+    // Sweep 0: 3 points
+    session.addVnaMeasurement(1e6, 3e6, 3,
+                              {1e6, 2e6, 3e6},
+                              {-10.0, -11.0, -12.0});
+    // Sweep 1: 2 points
+    session.addVnaMeasurement(4e6, 5e6, 2,
+                              {4e6, 5e6},
+                              {-13.0, -14.0});
+    session.end();
+
+    const QString path = tempFilePath();
+    QVERIFY(VnaCsvExporter::exportToFile(session, path));
+
+    const QStringList lines = readLines(path);
+    // 1 header + 3 + 2 = 6 lines.
+    QCOMPARE(lines.size(), 6);
+  }
+
+  // -------------------------------------------------------------------------
+  // Multiple sweeps: sweep_index increments per sweep
+  // -------------------------------------------------------------------------
+
+  void exportToFile_multiSweep_sweepIndexIncrements() {
+    ExperimentSession session;
+    session.start("M");
+    session.addVnaMeasurement(1e6, 2e6, 2, {1e6, 2e6}, {-10.0, -11.0});
+    session.addVnaMeasurement(3e6, 4e6, 2, {3e6, 4e6}, {-12.0, -13.0});
+    session.end();
+
+    const QString path = tempFilePath();
+    QVERIFY(VnaCsvExporter::exportToFile(session, path));
+
+    const QStringList lines = readLines(path);
+    // lines[1], lines[2] → sweep 0; lines[3], lines[4] → sweep 1.
+    QCOMPARE(lines.at(1).split(',').at(0), QStringLiteral("0"));
+    QCOMPARE(lines.at(2).split(',').at(0), QStringLiteral("0"));
+    QCOMPARE(lines.at(3).split(',').at(0), QStringLiteral("1"));
+    QCOMPARE(lines.at(4).split(',').at(0), QStringLiteral("1"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Values round-trip: start/stop frequency and magnitude preserved
+  // -------------------------------------------------------------------------
+
+  void exportToFile_singlePoint_valuesMatchInput() {
+    ExperimentSession session;
+    session.start("V");
+    session.addVnaMeasurement(1000000.0, 10000000.0, 1,
+                              {5000000.0},
+                              {-25.5});
+    session.end();
+
+    const QString path = tempFilePath();
+    QVERIFY(VnaCsvExporter::exportToFile(session, path));
+
+    const QStringList lines = readLines(path);
+    QCOMPARE(lines.size(), 2);
+
+    const QStringList cols = lines.at(1).split(',');
+    QCOMPARE(cols.size(), 6);
+    QCOMPARE(cols.at(0), QStringLiteral("0"));
+    // start_frequency_hz — written as integer (f,0)
+    QCOMPARE(cols.at(2), QStringLiteral("1000000"));
+    QCOMPARE(cols.at(3), QStringLiteral("10000000"));
+    // frequency_hz and magnitude_db — written with 6 decimal places
+    QCOMPARE(cols.at(4), QStringLiteral("5000000.000000"));
+    QCOMPARE(cols.at(5), QStringLiteral("-25.500000"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Timestamp: present and non-empty in each data row
+  // -------------------------------------------------------------------------
+
+  void exportToFile_dataRows_timestampNonEmpty() {
+    ExperimentSession session;
+    session.start("T");
+    session.addVnaMeasurement(1e6, 2e6, 2, {1e6, 2e6}, {-10.0, -11.0});
+    session.end();
+
+    const QString path = tempFilePath();
+    QVERIFY(VnaCsvExporter::exportToFile(session, path));
+
+    const QStringList lines = readLines(path);
+    for (int i = 1; i < lines.size(); ++i) {
+      const QStringList cols = lines.at(i).split(',');
+      QVERIFY2(!cols.at(1).isEmpty(), "timestamp column must not be empty");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Multiple sweeps: each sweep's rows share the same timestamp
+  // -------------------------------------------------------------------------
+
+  void exportToFile_sweepRows_shareTimestamp() {
+    ExperimentSession session;
+    session.start("TS");
+    session.addVnaMeasurement(1e6, 3e6, 3,
+                              {1e6, 2e6, 3e6},
+                              {-10.0, -11.0, -12.0});
+    session.end();
+
+    const QString path = tempFilePath();
+    QVERIFY(VnaCsvExporter::exportToFile(session, path));
+
+    const QStringList lines = readLines(path);
+    // All three data rows must have the same timestamp (column 1).
+    const QString ts0 = lines.at(1).split(',').at(1);
+    QCOMPARE(lines.at(2).split(',').at(1), ts0);
+    QCOMPARE(lines.at(3).split(',').at(1), ts0);
+  }
+
+  // -------------------------------------------------------------------------
+  // Error handling: unwritable path
+  // -------------------------------------------------------------------------
+
+  void exportToFile_failsOnUnwritablePath() {
+    ExperimentSession session;
+    session.start("R");
+    session.end();
+
+    const bool ok = VnaCsvExporter::exportToFile(
+        session, QStringLiteral("/nonexistent_dir/mwa_test.csv"));
+
+    QVERIFY(!ok);
+    QVERIFY(!VnaCsvExporter::lastError().isEmpty());
+  }
+
+  // -------------------------------------------------------------------------
+  // lastError() is cleared on success
+  // -------------------------------------------------------------------------
+
+  void lastError_clearedAfterSuccess() {
+    // Trigger a failure first.
+    ExperimentSession session;
+    session.start("R");
+    session.end();
+    VnaCsvExporter::exportToFile(
+        session, QStringLiteral("/nonexistent_dir/mwa_test.csv"));
+    QVERIFY(!VnaCsvExporter::lastError().isEmpty());
+
+    // Successful export must clear it.
+    const QString path = tempFilePath();
+    QVERIFY(VnaCsvExporter::exportToFile(session, path));
+    QVERIFY(VnaCsvExporter::lastError().isEmpty());
+  }
+
+  // -------------------------------------------------------------------------
+  // Overwrites existing file
+  // -------------------------------------------------------------------------
+
+  void exportToFile_overwritesExistingFile() {
+    ExperimentSession s1;
+    s1.start("S1");
+    s1.addVnaMeasurement(1e6, 2e6, 2, {1e6, 2e6}, {-10.0, -11.0});
+    s1.end();
+
+    const QString path = tempFilePath();
+    QVERIFY(VnaCsvExporter::exportToFile(s1, path));
+    const int first_line_count = readLines(path).size();
+
+    // Export a different (empty) session to the same path.
+    ExperimentSession s2;
+    s2.start("S2");
+    s2.end();
+    QVERIFY(VnaCsvExporter::exportToFile(s2, path));
+
+    const QStringList lines = readLines(path);
+    // Empty session → header only → fewer lines than before.
+    QCOMPARE(lines.size(), 1);
+    QVERIFY(first_line_count > lines.size());
+  }
+};
+
+QTEST_MAIN(TestVnaCsvExporter)
+#include "test_vna_csv_exporter.moc"


### PR DESCRIPTION
## Summary

- Adds `VnaCsvExporter` (`src/analysis/vna_csv_exporter.h/.cpp`) — stateless utility (static methods + `lastError()`) that exports all `VnaMeasurement` entries from an `ExperimentSession` to a single CSV file
- CSV format: one row per sweep point — columns `sweep_index`, `timestamp` (ISO-8601 ms), `start_frequency_hz`, `stop_frequency_hz`, `frequency_hz`, `magnitude_db`
- Overwrites existing file; empty session writes header only (no crash)
- Follows the exact same pattern as `SessionSerializer` (static methods, `lastError()`, `QFile`/`QTextStream`)
- 14 unit tests in `tests/test_vna_csv_exporter.cpp` — all pass locally

## Handoff Summary

**What to review:**
- `src/analysis/vna_csv_exporter.h` — public API and Doxygen docs
- `src/analysis/vna_csv_exporter.cpp` — implementation
- `tests/test_vna_csv_exporter.cpp` — 14 tests

**What to test manually (optional):**
1. Build and run `test_vna_csv_exporter` — expect 14 PASS, 0 FAIL
2. Open a CSV output in Excel/Numbers and verify columns parse correctly

**What to focus on:**
- CSV column ordering and naming (matches ANA-REQ-007 intent)
- Numeric precision: start/stop frequency written as integer (`f,0`), per-point frequency and magnitude with 6 decimal places

🤖 Generated with [Claude Code](https://claude.com/claude-code)