### PR TITLE
simplify(MWA-12-D): replace parallel ternaries with FormatStrings switch helper

### DIFF
--- a/src/analysis/camera_frame_exporter.cpp
+++ b/src/analysis/camera_frame_exporter.cpp
@@ -21,6 +21,27 @@ namespace mwa::analysis {
 QString CameraFrameExporter::last_error_;
 
 // ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct FormatStrings {
+  const char* extension;  ///< File extension, e.g. "png".
+  const char* qt_format;  ///< Qt image format id, e.g. "PNG".
+};
+
+FormatStrings formatStrings(ImageFormat fmt) noexcept {
+  switch (fmt) {
+    case ImageFormat::kPng:  return {"png",  "PNG"};
+    case ImageFormat::kTiff: return {"tiff", "TIFF"};
+  }
+  Q_UNREACHABLE();
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
 // exportToDir()
 // ---------------------------------------------------------------------------
 
@@ -34,9 +55,7 @@ bool CameraFrameExporter::exportToDir(const ExperimentSession& session,
     return false;
   }
 
-  const bool is_tiff = (format == ImageFormat::kTiff);
-  const char* const extension = is_tiff ? "tiff" : "png";
-  const char* const qt_format = is_tiff ? "TIFF" : "PNG";
+  const auto [extension, qt_format] = formatStrings(format);
 
   const QVector<CameraFrame>& frames = session.cameraFrames();
   for (int i = 0; i < frames.size(); ++i) {


### PR DESCRIPTION
## PR Handoff Summary for Owner

### What Changed
- `src/analysis/camera_frame_exporter.cpp` — replaced `is_tiff` bool + two parallel `const char*` ternaries with a `FormatStrings` struct and a `switch`-based `formatStrings()` helper in an anonymous namespace

### Requirement IDs Addressed
- Follow-up cleanup to ANA-REQ-001 (no new requirements addressed)

### What to Test (Owner Manual Testing)
- Build the project — zero warnings expected
- Run `test_camera_frame_exporter` — all 14 tests must still pass (no behaviour change)

### What to Focus On
- The change is purely internal to `camera_frame_exporter.cpp` — no public API surface changes
- Adding a new `ImageFormat` value (e.g. `kJpeg`) now requires a single `case` entry with both strings co-located, rather than updating two separate ternaries

### Doxygen Documentation Check
- No public API changes — no Doxygen updates required

### Test Results Summary
- Total tests: 14
- Passed: 14
- Failed: 0
- Platforms tested: macOS

### Known Issues / Limitations
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)