### PR TITLE
feat(MWA-15): session recording control

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -6,7 +6,9 @@ add_library(MwaApp STATIC
 target_include_directories(MwaApp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 target_link_libraries(MwaApp PUBLIC
+  MwaAnalysis
   MwaCore
+  MwaDialogs
   MwaGui
   MwaPanels
   Qt6::Core

--- a/src/app/main_window.cpp
+++ b/src/app/main_window.cpp
@@ -14,13 +14,25 @@
 #include "app/main_window.h"
 
 #include <QApplication>
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
 #include <QKeySequence>
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QStatusBar>
 #include <QVBoxLayout>
 
+#include "analysis/experiment_session.h"
+#include "analysis/session_serializer.h"
 #include "core/settings_manager.h"
+#include "gui/dialogs/new_session_dialog.h"
+#include "hardware/camera/camera_controller_interface.h"
+#include "hardware/led/led_controller_interface.h"
+#include "hardware/network_analyzer/network_analyzer_controller_interface.h"
+#include "hardware/pump/pump_controller_interface.h"
+#include "hardware/signal_generator/signal_generator_controller_interface.h"
+#include "hardware/stage/stage_controller_interface.h"
 #include "gui/panels/analysis_panel.h"
 #include "gui/panels/camera_panel.h"
 #include "gui/panels/led_panel.h"
@@ -77,6 +89,31 @@ MainWindow::~MainWindow() = default;
 // ---- closeEvent -------------------------------------------------------
 
 void MainWindow::closeEvent(QCloseEvent* event) {
+  if (active_session_ && active_session_->isActive()) {
+    QMessageBox msgbox(this);
+    msgbox.setWindowTitle(QStringLiteral("Recording In Progress"));
+    msgbox.setText(
+        QStringLiteral(
+            "A session is currently recording.\n"
+            "Stop recording and close?"));
+    msgbox.setIcon(QMessageBox::Warning);
+    auto* btn_stop = msgbox.addButton(
+        QStringLiteral("Stop && Close"), QMessageBox::AcceptRole);
+    msgbox.addButton(QMessageBox::Cancel);
+    msgbox.setDefaultButton(btn_stop);
+    msgbox.exec();
+
+    if (msgbox.clickedButton() != btn_stop) {
+      event->ignore();
+      return;
+    }
+
+    disconnectRecordingSignals();
+    active_session_->end();
+    active_session_->deleteLater();
+    active_session_ = nullptr;
+  }
+
   saveSettings();
   event->accept();
 }
@@ -220,7 +257,7 @@ void MainWindow::createActions() {
   action_start_experiment_->setShortcut(QKeySequence(Qt::Key_F5));
   action_start_experiment_->setToolTip(
       QStringLiteral("Start Experiment (F5)"));
-  action_start_experiment_->setEnabled(false);
+  action_start_experiment_->setEnabled(true);
 
   action_stop_experiment_ =
       new QAction(QStringLiteral("S&top"), this);
@@ -489,11 +526,20 @@ void MainWindow::createStatusBar() {
       QStringLiteral("Last event: Application started"));
   lbl_last_event_->setObjectName(QStringLiteral("lblLastEvent"));
 
+  lbl_recording_indicator_ = new QLabel(this);
+  lbl_recording_indicator_->setObjectName(
+      QStringLiteral("lblRecordingIndicator"));
+  lbl_recording_indicator_->setStyleSheet(
+      QStringLiteral(
+          "color: #E74C3C; font-weight: bold; padding: 0 8px;"));
+  lbl_recording_indicator_->setVisible(false);
+
   lbl_version_ = new QLabel(QStringLiteral("MWA v0.1.0"));
   lbl_version_->setObjectName(QStringLiteral("lblVersion"));
 
   statusBar()->addWidget(lbl_device_summary_);
   statusBar()->addWidget(lbl_last_event_, 1);
+  statusBar()->addPermanentWidget(lbl_recording_indicator_);
   statusBar()->addPermanentWidget(lbl_version_);
 }
 
@@ -541,6 +587,12 @@ void MainWindow::connectSignals() {
   // Logger integration — update last-event label
   connect(&mwa::core::Logger::instance(), &mwa::core::Logger::newLogEntry,
           this, &MainWindow::onNewLogEntry);
+
+  // Experiment recording
+  connect(action_start_experiment_, &QAction::triggered,
+          this, &MainWindow::onActionStartExperiment);
+  connect(action_stop_experiment_, &QAction::triggered,
+          this, &MainWindow::onActionStopExperiment);
 }
 
 // ---- restoreSettings --------------------------------------------------
@@ -586,6 +638,172 @@ void MainWindow::saveSettings() {
   settings.setValue(grp, QLatin1String(kKeyStatusBarVisible),
                     statusBar()->isVisible());
 
+  settings.saveAll();
+}
+
+// ---- Session recording slots ------------------------------------------
+
+void MainWindow::onActionStartExperiment() {
+  mwa::gui::NewSessionDialog dialog(this);
+  if (dialog.exec() != QDialog::Accepted) {
+    return;
+  }
+
+  active_session_ = new mwa::analysis::ExperimentSession(this);
+  connect(active_session_,
+          &mwa::analysis::ExperimentSession::sessionStarted,
+          this, &MainWindow::onSessionStarted);
+  connect(active_session_,
+          &mwa::analysis::ExperimentSession::sessionEnded,
+          this, &MainWindow::onSessionEnded);
+
+  active_session_->start(dialog.name(), dialog.description());
+  connectRecordingSignals();
+}
+
+void MainWindow::onActionStopExperiment() {
+  disconnectRecordingSignals();
+  active_session_->end();
+  promptSaveSession();
+  active_session_->deleteLater();
+  active_session_ = nullptr;
+}
+
+void MainWindow::onSessionStarted(const QString& name) {
+  action_start_experiment_->setEnabled(false);
+  action_stop_experiment_->setEnabled(true);
+  lbl_recording_indicator_->setText(
+      QStringLiteral("\u25cf REC  ") + name);
+  lbl_recording_indicator_->setVisible(true);
+}
+
+void MainWindow::onSessionEnded() {
+  action_start_experiment_->setEnabled(true);
+  action_stop_experiment_->setEnabled(false);
+  lbl_recording_indicator_->setVisible(false);
+}
+
+void MainWindow::onVnaMeasurementComplete() {
+  active_session_->addVnaMeasurement(
+      net_analyzer_controller_->startFrequency(),
+      net_analyzer_controller_->stopFrequency(),
+      net_analyzer_controller_->numPoints(),
+      net_analyzer_controller_->traceFrequencies(),
+      net_analyzer_controller_->traceMagnitudes());
+}
+
+// ---- Recording signal management --------------------------------------
+
+void MainWindow::connectRecordingSignals() {
+  auto* s = active_session_;
+
+  recording_connections_ << connect(
+      led_controller_,
+      &mwa::hardware::LedControllerInterface::intensityChanged,
+      this, [this, s](double percent) {
+        s->addLedSample(led_controller_->isPowerOn(), percent);
+      });
+  recording_connections_ << connect(
+      led_controller_,
+      &mwa::hardware::LedControllerInterface::powerStateChanged,
+      this, [this, s](bool on) {
+        s->addLedSample(on, led_controller_->intensity());
+      });
+  recording_connections_ << connect(
+      pump_controller_,
+      &mwa::hardware::PumpControllerInterface::positionChanged,
+      this, [this, s](double uL) {
+        s->addPumpSample(uL, pump_controller_->flowRate());
+      });
+  recording_connections_ << connect(
+      sig_gen_controller_,
+      &mwa::hardware::SignalGeneratorControllerInterface::frequencyChanged,
+      this, [this, s](double hz) {
+        s->addSigGenSample(hz, sig_gen_controller_->amplitude());
+      });
+  recording_connections_ << connect(
+      camera_controller_,
+      &mwa::hardware::CameraControllerInterface::frameReady,
+      s, &mwa::analysis::ExperimentSession::addCameraFrame);
+  recording_connections_ << connect(
+      stage_controller_,
+      &mwa::hardware::StageControllerInterface::positionChanged,
+      s, &mwa::analysis::ExperimentSession::addStageSample);
+  recording_connections_ << connect(
+      net_analyzer_controller_,
+      &mwa::hardware::NetworkAnalyzerControllerInterface::measurementComplete,
+      this, &MainWindow::onVnaMeasurementComplete);
+}
+
+void MainWindow::disconnectRecordingSignals() {
+  for (const auto& conn : recording_connections_) {
+    disconnect(conn);
+  }
+  recording_connections_.clear();
+}
+
+// ---- Save prompt ------------------------------------------------------
+
+void MainWindow::promptSaveSession() {
+  QMessageBox msgbox(this);
+  msgbox.setWindowTitle(QStringLiteral("Save Session"));
+  msgbox.setText(
+      QStringLiteral("Session \"%1\" has ended.\nSave to file?")
+          .arg(active_session_->name()));
+  msgbox.setIcon(QMessageBox::Question);
+  auto* btn_save =
+      msgbox.addButton(QStringLiteral("Save\u2026"), QMessageBox::AcceptRole);
+  auto* btn_discard =
+      msgbox.addButton(QStringLiteral("Discard"), QMessageBox::DestructiveRole);
+  msgbox.setDefaultButton(btn_save);
+  msgbox.exec();
+
+  if (msgbox.clickedButton() != btn_save) {
+    Q_UNUSED(btn_discard)
+    return;
+  }
+
+  const QString safe_name =
+      active_session_->name().simplified()
+          .replace(QLatin1Char(' '), QLatin1Char('_'));
+  const QString date_str =
+      active_session_->startTime().toString(
+          QStringLiteral("yyyy-MM-dd"));
+  const QString default_name =
+      safe_name + QLatin1Char('_') + date_str +
+      QStringLiteral(".json");
+
+  auto& settings = mwa::core::SettingsManager::instance();
+  const QString last_path =
+      settings.value(QStringLiteral("Session"),
+                     QStringLiteral("lastFilePath")).toString();
+  const QString start_dir =
+      last_path.isEmpty()
+          ? QDir::homePath()
+          : QFileInfo(last_path).absoluteDir().absolutePath();
+
+  const QString path = QFileDialog::getSaveFileName(
+      this,
+      QStringLiteral("Save Session"),
+      start_dir + QDir::separator() + default_name,
+      QStringLiteral("MWA Session (*.json)"));
+
+  if (path.isEmpty()) {
+    return;
+  }
+
+  if (!mwa::analysis::SessionSerializer::save(*active_session_, path)) {
+    QMessageBox::warning(
+        this,
+        QStringLiteral("Save Failed"),
+        QStringLiteral("Could not write session file:\n%1\n\n%2")
+            .arg(path,
+                 mwa::analysis::SessionSerializer::lastError()));
+    return;
+  }
+
+  settings.setValue(QStringLiteral("Session"),
+                    QStringLiteral("lastFilePath"), path);
   settings.saveAll();
 }
 

--- a/src/app/main_window.h
+++ b/src/app/main_window.h
@@ -18,8 +18,10 @@
 #include <QCloseEvent>
 #include <QDockWidget>
 #include <QLabel>
+#include <QList>
 #include <QMainWindow>
 #include <QMenu>
+#include <QMetaObject>
 #include <QStackedWidget>
 #include <QToolBar>
 
@@ -34,6 +36,11 @@ class CameraPanel;
 class StagePanel;
 class AnalysisPanel;
 }  // namespace mwa::gui
+
+// Forward declaration for session data model
+namespace mwa::analysis {
+class ExperimentSession;
+}  // namespace mwa::analysis
 
 // Forward declarations for device controller interfaces
 namespace mwa::hardware {
@@ -121,6 +128,43 @@ class MainWindow : public QMainWindow {
    */
   void onActionAbout();
 
+  /**
+   * @brief Handle Experiment > Start action (F5).
+   *
+   * Opens NewSessionDialog. On acceptance, creates an ExperimentSession,
+   * wires all device telemetry signals into it, and begins recording.
+   */
+  void onActionStartExperiment();
+
+  /**
+   * @brief Handle Experiment > Stop action (F6).
+   *
+   * Disconnects recording signals, ends the active session, and prompts
+   * the user to save the session to a JSON file.
+   */
+  void onActionStopExperiment();
+
+  /**
+   * @brief Update UI to reflect a recording session has started.
+   *
+   * @param name The session name passed to ExperimentSession::start().
+   */
+  void onSessionStarted(const QString& name);
+
+  /**
+   * @brief Update UI to reflect the active session has ended.
+   */
+  void onSessionEnded();
+
+  /**
+   * @brief Forward a completed VNA sweep into the active session.
+   *
+   * Called when NetworkAnalyzerControllerInterface::measurementComplete()
+   * fires. Reads trace data from the controller and calls
+   * ExperimentSession::addVnaMeasurement().
+   */
+  void onVnaMeasurementComplete();
+
  private:
   // ---- Setup helpers (called once from constructor) ----
 
@@ -173,6 +217,35 @@ class MainWindow : public QMainWindow {
    * @brief Persist window geometry and dock state via SettingsManager.
    */
   void saveSettings();
+
+  /**
+   * @brief Wire all device telemetry signals into the active session.
+   *
+   * Stores each connection in recording_connections_ so they can be
+   * cleanly disconnected by disconnectRecordingSignals().
+   *
+   * @pre active_session_ must be non-null and active.
+   */
+  void connectRecordingSignals();
+
+  /**
+   * @brief Disconnect all device-to-session telemetry connections.
+   *
+   * Disconnects every connection stored in recording_connections_ and
+   * clears the list.
+   */
+  void disconnectRecordingSignals();
+
+  /**
+   * @brief Prompt the user to save the just-ended session to a JSON file.
+   *
+   * Shows a Save/Discard dialog. If the user chooses Save, opens a file
+   * dialog and writes the session via SessionSerializer. Persists the
+   * chosen path to SettingsManager.
+   *
+   * @pre active_session_ must be non-null and ended (not active).
+   */
+  void promptSaveSession();
 
   // ---- Actions ----
 
@@ -243,7 +316,14 @@ class MainWindow : public QMainWindow {
   // Status bar labels (owned by the status bar via addWidget)
   QLabel* lbl_device_summary_{nullptr};
   QLabel* lbl_last_event_{nullptr};
+  QLabel* lbl_recording_indicator_{nullptr};
   QLabel* lbl_version_{nullptr};
+
+  // Session recording state
+  /// Active experiment session; null when not recording.
+  mwa::analysis::ExperimentSession* active_session_{nullptr};
+  /// Device-to-session signal connections active during recording.
+  QList<QMetaObject::Connection> recording_connections_;
 };
 
 }  // namespace mwa::app

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(widgets)
 add_subdirectory(panels)
+add_subdirectory(dialogs)

--- a/src/gui/dialogs/CMakeLists.txt
+++ b/src/gui/dialogs/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(MwaDialogs STATIC
+  new_session_dialog.h
+  new_session_dialog.cpp
+)
+
+target_include_directories(MwaDialogs PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+
+target_link_libraries(MwaDialogs PUBLIC
+  Qt6::Core
+  Qt6::Gui
+  Qt6::Widgets
+)

--- a/src/gui/dialogs/new_session_dialog.cpp
+++ b/src/gui/dialogs/new_session_dialog.cpp
@@ -1,0 +1,73 @@
+/**
+ * @file new_session_dialog.cpp
+ * @brief Dialog for creating a new experiment session.
+ * @author MWA Team
+ * @date 2026-04-07
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#include "gui/dialogs/new_session_dialog.h"
+
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+namespace mwa::gui {
+
+NewSessionDialog::NewSessionDialog(QWidget* parent) : QDialog(parent) {
+  setWindowTitle(QStringLiteral("New Experiment Session"));
+  setFixedWidth(420);
+  setModal(true);
+
+  edt_name_ = new QLineEdit(this);
+  edt_name_->setObjectName(QStringLiteral("edtSessionName"));
+  edt_name_->setPlaceholderText(QStringLiteral("e.g. Run 1"));
+
+  edt_description_ = new QPlainTextEdit(this);
+  edt_description_->setObjectName(
+      QStringLiteral("edtSessionDescription"));
+  edt_description_->setFixedHeight(72);
+  edt_description_->setPlaceholderText(
+      QStringLiteral("Optional free-text description"));
+
+  button_box_ = new QDialogButtonBox(
+      QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+  button_box_->setObjectName(QStringLiteral("buttonBox"));
+  button_box_->button(QDialogButtonBox::Ok)->setText(
+      QStringLiteral("Start"));
+  button_box_->button(QDialogButtonBox::Ok)->setEnabled(false);
+
+  auto* form_layout = new QFormLayout;
+  form_layout->addRow(QStringLiteral("Session Name *"), edt_name_);
+  form_layout->addRow(QStringLiteral("Description"),   edt_description_);
+
+  auto* layout = new QVBoxLayout(this);
+  layout->addLayout(form_layout);
+  layout->addWidget(button_box_);
+
+  connect(edt_name_, &QLineEdit::textChanged,
+          this,      &NewSessionDialog::onNameTextChanged);
+  connect(button_box_, &QDialogButtonBox::accepted,
+          this,        &QDialog::accept);
+  connect(button_box_, &QDialogButtonBox::rejected,
+          this,        &QDialog::reject);
+}
+
+QString NewSessionDialog::name() const {
+  return edt_name_->text().trimmed();
+}
+
+QString NewSessionDialog::description() const {
+  return edt_description_->toPlainText().trimmed();
+}
+
+void NewSessionDialog::onNameTextChanged(const QString& text) {
+  button_box_->button(QDialogButtonBox::Ok)->setEnabled(
+      !text.trimmed().isEmpty());
+}
+
+}  // namespace mwa::gui

--- a/src/gui/dialogs/new_session_dialog.h
+++ b/src/gui/dialogs/new_session_dialog.h
@@ -1,0 +1,74 @@
+/**
+ * @file new_session_dialog.h
+ * @brief Dialog for creating a new experiment session.
+ * @author MWA Team
+ * @date 2026-04-07
+ *
+ * Declares NewSessionDialog, a modal QDialog that collects a session name
+ * and optional description before a recording session begins.
+ *
+ * @copyright LGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <QDialog>
+#include <QString>
+
+class QDialogButtonBox;
+class QLineEdit;
+class QPlainTextEdit;
+
+namespace mwa::gui {
+
+/**
+ * @class NewSessionDialog
+ * @brief Modal dialog for entering new experiment session metadata.
+ *
+ * Collects a required session name and an optional free-text description.
+ * The OK ("Start") button is disabled until the name field is non-empty.
+ * Use name() and description() after exec() returns QDialog::Accepted to
+ * retrieve the entered values.
+ *
+ * @see mwa::analysis::ExperimentSession
+ */
+class NewSessionDialog : public QDialog {
+  Q_OBJECT
+
+ public:
+  /**
+   * @brief Construct the dialog.
+   *
+   * @param parent Optional parent widget; the dialog is modal to it.
+   */
+  explicit NewSessionDialog(QWidget* parent = nullptr);
+
+  /**
+   * @brief Return the session name entered by the user.
+   *
+   * @return Trimmed session name. Empty if rejected or left blank.
+   */
+  [[nodiscard]] QString name() const;
+
+  /**
+   * @brief Return the optional description entered by the user.
+   *
+   * @return Description string, or an empty string if not provided.
+   */
+  [[nodiscard]] QString description() const;
+
+ private slots:
+  /**
+   * @brief Enable or disable OK based on the name field content.
+   *
+   * @param text The current text in the name field.
+   */
+  void onNameTextChanged(const QString& text);
+
+ private:
+  QLineEdit*        edt_name_{nullptr};
+  QPlainTextEdit*   edt_description_{nullptr};
+  QDialogButtonBox* button_box_{nullptr};
+};
+
+}  // namespace mwa::gui

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -389,6 +389,21 @@ target_link_libraries(test_camera_frame_exporter PRIVATE
 add_test(NAME test_camera_frame_exporter COMMAND test_camera_frame_exporter)
 
 # ---------------------------------------------------------------------------
+# NewSessionDialog tests
+# ---------------------------------------------------------------------------
+add_executable(test_new_session_dialog test_new_session_dialog.cpp)
+
+target_link_libraries(test_new_session_dialog PRIVATE
+  MwaDialogs
+  Qt6::Core
+  Qt6::Gui
+  Qt6::Widgets
+  Qt6::Test
+)
+
+add_test(NAME test_new_session_dialog COMMAND test_new_session_dialog)
+
+# ---------------------------------------------------------------------------
 # AnalysisPanel tests
 # ---------------------------------------------------------------------------
 add_executable(test_analysis_panel test_analysis_panel.cpp)

--- a/tests/test_main_window.cpp
+++ b/tests/test_main_window.cpp
@@ -82,10 +82,14 @@ class TestMainWindow : public QObject {
   void test_actionNewExperiment_isDisabled();
   void test_actionOpenExperiment_isDisabled();
   void test_actionSaveExperiment_isDisabled();
-  void test_actionStartExperiment_isDisabled();
   void test_actionStopExperiment_isDisabled();
   void test_actionPreferences_isDisabled();
   void test_actionExportLog_isDisabled();
+
+  // --- Recording control initial state ---
+  void test_actionStartExperiment_isEnabled();
+  void test_lblRecordingIndicator_exists();
+  void test_lblRecordingIndicator_isInitiallyHidden();
 
   // --- View toggle actions: enabled, checkable, and initially checked ---
   void test_actionToggleLeftDock_isEnabled();
@@ -352,13 +356,6 @@ void TestMainWindow::test_actionSaveExperiment_isDisabled() {
   QVERIFY(action != nullptr);
   QVERIFY2(!action->isEnabled(),
            "actionSaveExperiment must be disabled (placeholder)");
-}
-
-void TestMainWindow::test_actionStartExperiment_isDisabled() {
-  auto* action = window_->findChild<QAction*>("actionStartExperiment");
-  QVERIFY(action != nullptr);
-  QVERIFY2(!action->isEnabled(),
-           "actionStartExperiment must be disabled (placeholder)");
 }
 
 void TestMainWindow::test_actionStopExperiment_isDisabled() {
@@ -764,6 +761,30 @@ void TestMainWindow::test_toggleToolbar_falseThentrue_showsToolbarAgain() {
   QVERIFY2(!tb->isHidden(),
            "mainToolbar must not be hidden after actionToggleToolbar "
            "is re-checked");
+}
+
+// ===========================================================================
+// Recording control initial state
+// ===========================================================================
+
+void TestMainWindow::test_actionStartExperiment_isEnabled() {
+  auto* action = window_->findChild<QAction*>("actionStartExperiment");
+  QVERIFY(action != nullptr);
+  QVERIFY2(action->isEnabled(),
+           "actionStartExperiment must be enabled on construction "
+           "(recording is always available)");
+}
+
+void TestMainWindow::test_lblRecordingIndicator_exists() {
+  auto* lbl = window_->findChild<QLabel*>("lblRecordingIndicator");
+  QVERIFY2(lbl != nullptr, "lblRecordingIndicator must exist in status bar");
+}
+
+void TestMainWindow::test_lblRecordingIndicator_isInitiallyHidden() {
+  auto* lbl = window_->findChild<QLabel*>("lblRecordingIndicator");
+  QVERIFY(lbl != nullptr);
+  QVERIFY2(lbl->isHidden(),
+           "lblRecordingIndicator must be hidden when no session is active");
 }
 
 // ===========================================================================

--- a/tests/test_new_session_dialog.cpp
+++ b/tests/test_new_session_dialog.cpp
@@ -1,0 +1,164 @@
+/**
+ * @file test_new_session_dialog.cpp
+ * @brief Adversarial tests for mwa::gui::NewSessionDialog.
+ * @date 2026-04-07
+ * @copyright LGPL-3.0-or-later
+ *
+ * Tests cover construction, name field validation (OK button state),
+ * accessor methods, and whitespace-only rejection.
+ */
+
+#include <QApplication>
+#include <QDialogButtonBox>
+#include <QLineEdit>
+#include <QObject>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QtTest>
+
+#include "gui/dialogs/new_session_dialog.h"
+
+using mwa::gui::NewSessionDialog;
+
+// ---------------------------------------------------------------------------
+class TestNewSessionDialog : public QObject {
+  Q_OBJECT
+
+ private slots:
+  void init();
+  void cleanup();
+
+  // --- Construction ---
+  void test_constructs_withoutCrash();
+  void test_windowTitle_isCorrect();
+
+  // --- Name field / OK button state ---
+  void test_okButton_isDisabled_initially();
+  void test_okButton_enables_whenNameIsNonEmpty();
+  void test_okButton_disables_whenNameIsCleared();
+  void test_okButton_stays_disabled_forWhitespaceOnlyName();
+
+  // --- Accessors ---
+  void test_name_returnsEmptyString_initially();
+  void test_name_returnsTrimmedText_afterInput();
+  void test_description_returnsEmptyString_initially();
+  void test_description_returnsText_afterInput();
+
+ private:
+  NewSessionDialog* dialog_{nullptr};
+};
+
+// ---------------------------------------------------------------------------
+void TestNewSessionDialog::init() {
+  dialog_ = new NewSessionDialog();
+}
+
+void TestNewSessionDialog::cleanup() {
+  delete dialog_;
+  dialog_ = nullptr;
+}
+
+// ===========================================================================
+// Construction
+// ===========================================================================
+
+void TestNewSessionDialog::test_constructs_withoutCrash() {
+  QVERIFY(dialog_ != nullptr);
+}
+
+void TestNewSessionDialog::test_windowTitle_isCorrect() {
+  QCOMPARE(dialog_->windowTitle(),
+           QStringLiteral("New Experiment Session"));
+}
+
+// ===========================================================================
+// Name field / OK button state
+// ===========================================================================
+
+void TestNewSessionDialog::test_okButton_isDisabled_initially() {
+  auto* box = dialog_->findChild<QDialogButtonBox*>("buttonBox");
+  QVERIFY(box != nullptr);
+  auto* ok = box->button(QDialogButtonBox::Ok);
+  QVERIFY2(ok != nullptr, "OK button must exist in buttonBox");
+  QVERIFY2(!ok->isEnabled(),
+           "OK button must be disabled when name field is empty");
+}
+
+void TestNewSessionDialog::test_okButton_enables_whenNameIsNonEmpty() {
+  auto* edt = dialog_->findChild<QLineEdit*>("edtSessionName");
+  QVERIFY(edt != nullptr);
+  edt->setText(QStringLiteral("Run 1"));
+  QApplication::processEvents();
+
+  auto* box = dialog_->findChild<QDialogButtonBox*>("buttonBox");
+  QVERIFY(box != nullptr);
+  auto* ok = box->button(QDialogButtonBox::Ok);
+  QVERIFY2(ok->isEnabled(),
+           "OK button must be enabled when name field has text");
+}
+
+void TestNewSessionDialog::test_okButton_disables_whenNameIsCleared() {
+  auto* edt = dialog_->findChild<QLineEdit*>("edtSessionName");
+  QVERIFY(edt != nullptr);
+  edt->setText(QStringLiteral("Run 1"));
+  QApplication::processEvents();
+  edt->clear();
+  QApplication::processEvents();
+
+  auto* box = dialog_->findChild<QDialogButtonBox*>("buttonBox");
+  QVERIFY(box != nullptr);
+  auto* ok = box->button(QDialogButtonBox::Ok);
+  QVERIFY2(!ok->isEnabled(),
+           "OK button must re-disable when name field is cleared");
+}
+
+void TestNewSessionDialog::test_okButton_stays_disabled_forWhitespaceOnlyName() {
+  auto* edt = dialog_->findChild<QLineEdit*>("edtSessionName");
+  QVERIFY(edt != nullptr);
+  // Spaces only — trimmed result is empty, so OK must stay disabled.
+  edt->setText(QStringLiteral("   "));
+  QApplication::processEvents();
+
+  auto* box = dialog_->findChild<QDialogButtonBox*>("buttonBox");
+  QVERIFY(box != nullptr);
+  auto* ok = box->button(QDialogButtonBox::Ok);
+  QVERIFY2(!ok->isEnabled(),
+           "OK button must remain disabled for whitespace-only name");
+}
+
+// ===========================================================================
+// Accessors
+// ===========================================================================
+
+void TestNewSessionDialog::test_name_returnsEmptyString_initially() {
+  QVERIFY2(dialog_->name().isEmpty(),
+           "name() must return empty string before any input");
+}
+
+void TestNewSessionDialog::test_name_returnsTrimmedText_afterInput() {
+  auto* edt = dialog_->findChild<QLineEdit*>("edtSessionName");
+  QVERIFY(edt != nullptr);
+  edt->setText(QStringLiteral("  Run 42  "));
+  QApplication::processEvents();
+
+  QCOMPARE(dialog_->name(), QStringLiteral("Run 42"));
+}
+
+void TestNewSessionDialog::test_description_returnsEmptyString_initially() {
+  QVERIFY2(dialog_->description().isEmpty(),
+           "description() must return empty string before any input");
+}
+
+void TestNewSessionDialog::test_description_returnsText_afterInput() {
+  auto* edt = dialog_->findChild<QPlainTextEdit*>("edtSessionDescription");
+  QVERIFY(edt != nullptr);
+  edt->setPlainText(QStringLiteral("Focused flow test at 1 MHz"));
+  QApplication::processEvents();
+
+  QCOMPARE(dialog_->description(),
+           QStringLiteral("Focused flow test at 1 MHz"));
+}
+
+// ---------------------------------------------------------------------------
+QTEST_MAIN(TestNewSessionDialog)
+#include "test_new_session_dialog.moc"


### PR DESCRIPTION
## Summary

- **NewSessionDialog** (`src/gui/dialogs/`) — modal dialog collecting session name (required) and optional description before recording starts; OK button disabled until name is non-empty
- **Session recording in MainWindow** — enables F5/Start and F6/Stop actions; wires all 6 device telemetry signals into `ExperimentSession` via `connectRecordingSignals()`; `● REC <name>` indicator appears in status bar while active
- **Stop flow** — disconnects telemetry, ends session, prompts Save/Discard, writes JSON via `SessionSerializer`, persists last file path in `SettingsManager`
- **Close guard** — `closeEvent` asks "Stop & Close?" if a session is active; Cancel keeps window open

## Requirements

- ANA-REQ-001 (Image Batch Management — session recording is the prerequisite)

## Files changed

| File | Change |
|---|---|
| `src/gui/dialogs/new_session_dialog.h/.cpp` | NEW — session name/description dialog |
| `src/gui/dialogs/CMakeLists.txt` | NEW — MwaDialogs static lib |
| `src/gui/CMakeLists.txt` | add_subdirectory(dialogs) |
| `src/app/CMakeLists.txt` | link MwaAnalysis + MwaDialogs |
| `src/app/main_window.h` | recording members, slots, helpers |
| `src/app/main_window.cpp` | full recording implementation |
| `tests/test_main_window.cpp` | update Start→enabled, add indicator tests |
| `tests/test_new_session_dialog.cpp` | NEW — 10 adversarial dialog tests |
| `tests/CMakeLists.txt` | register test_new_session_dialog |

## What to test

1. Launch app → Experiment > Start (F5) → dialog opens, OK disabled until name typed, Enter confirms
2. After start: toolbar Start greyed, Stop enabled, `● REC <name>` visible in status bar right side
3. Interact with any device panel slider/control → confirm signals route (log events appear)
4. Experiment > Stop (F6) → "Save Session?" dialog → Save → choose path → verify JSON loads in Analysis panel
5. Start recording, then File > Exit → "Stop & Close?" confirmation appears, Cancel keeps app open

## Handoff summary

This is a pure wiring task — no new data model, no new hardware code. The entire change lives in `main_window.cpp` (new slots + helpers), the `MwaDialogs` library (one dialog), and test updates. No changes to device interfaces, session model, or serializer.

Known limitation: with mock controllers, device signals only fire when the user interacts with panels (sliders, buttons). Continuous real-time telemetry requires real hardware (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)